### PR TITLE
Use existing index for referencing side of FOREIGN KEY

### DIFF
--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/ais/model/AISBuilder.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/ais/model/AISBuilder.java
@@ -745,13 +745,6 @@ public class AISBuilder {
             checkFound(column, "creating foreign key", "referenced column",
                        concat(referencedSchemaName, referencedTableName, columnName));
             referencedColumns.add(column);
-        } 
-        // Add the (new) referencing index. Also takes care of duplicate fk name.
-        // IndexName must be the same as foreign key constraintName
-        index(referencingSchemaName, referencingTableName, name);
-        for (int i = 0; i < referencingColumnNames.size(); i++) {
-            indexColumn(referencingSchemaName, referencingTableName, name,
-                        referencingColumnNames.get(i), i, true, null);
         }
         ForeignKey.create(ais, name,
                           referencingTable, referencingColumns,

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/ais/model/AISMerge.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/ais/model/AISMerge.java
@@ -475,9 +475,6 @@ public class AISMerge {
 
         if (sourceTable.getPrimaryKeyIncludingInternal() != null) {
             TableIndex index = sourceTable.getPrimaryKeyIncludingInternal().getIndex();
-            final int rootTableID = (targetGroup != null) ? 
-                    targetGroup.getRoot().getTableId() : 
-                        builder.akibanInformationSchema().getTable(sourceTable.getName()).getTableId();
             IndexName indexName = index.getIndexName();
             builder.index(sourceTable.getName().getSchemaName(), 
                     sourceTable.getName().getTableName(),

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/ais/model/AISMerge.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/ais/model/AISMerge.java
@@ -501,7 +501,8 @@ public class AISMerge {
         builder.groupingIsComplete();
         
         for (TableIndex index : sourceTable.getIndexes()) {
-            if (!index.isPrimaryKey() && !index.isConnectedToFK()) {
+            // PRIMARY is added above as it is needed before groupingIsComplete()
+            if (!index.isPrimaryKey()) {
                 mergeIndex(index);
             }
         }

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/ais/model/DefaultNameGenerator.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/ais/model/DefaultNameGenerator.java
@@ -17,6 +17,7 @@
 
 package com.foundationdb.ais.model;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -34,7 +35,7 @@ import org.slf4j.LoggerFactory;
 public class DefaultNameGenerator implements NameGenerator {
     private static final Logger LOG = LoggerFactory.getLogger(DefaultNameGenerator.class);
 
-    static final int MAX_IDENT = 64;
+    public static final int MAX_IDENT = 64;
     static final String IDENTITY_SEQUENCE_FORMAT = "%s_%s_seq";
 
     // Use 1 as default offset because the AAM uses tableID 0 as a marker value.
@@ -248,7 +249,7 @@ public class DefaultNameGenerator implements NameGenerator {
     }
 
     /** Find a name that would be unique if added to {@code set}. */
-    private static TableName findUnique(Set<TableName> set, TableName original) {
+    private static TableName findUnique(Collection<TableName> set, TableName original) {
         int counter = 1;
         String baseName = original.getTableName();
         TableName proposed = original;
@@ -263,7 +264,7 @@ public class DefaultNameGenerator implements NameGenerator {
         return proposed;
     }
 
-    public static String findUnique(Set<String> set, String original, int maxLength) {
+    public static String findUnique(Collection<String> set, String original, int maxLength) {
         int counter = 1;
         String baseName = original;
         String proposed = original;
@@ -278,7 +279,7 @@ public class DefaultNameGenerator implements NameGenerator {
         return proposed;
     }
 
-    public static String makeUnique(Set<String> treeNames, String proposed, int maxLength) {
+    public static String makeUnique(Collection<String> treeNames, String proposed, int maxLength) {
         String actual = findUnique(treeNames, proposed, maxLength);
         treeNames.add(actual);
         return actual;

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/ais/model/Index.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/ais/model/Index.java
@@ -113,14 +113,6 @@ public abstract class Index extends HasStorage implements Visitable, Constraint
         return isPrimary;
     }
 
-    public boolean isConnectedToFK() {
-        Schema schema = getAIS().getSchema(this.getSchemaName());
-        if (schema.hasConstraint(indexName.getName()) && (schema.getConstraint(indexName.getName()) instanceof ForeignKey)) {
-            return true;
-        }
-        return false;
-    }
-
     public IndexName getIndexName()
     {
         return indexName;

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/ais/model/validation/ForeignKeyIndexes.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/ais/model/validation/ForeignKeyIndexes.java
@@ -33,10 +33,10 @@ class ForeignKeyIndexes implements AISValidation {
             for (ForeignKey foreignKey : table.getForeignKeys()) {
                 if (foreignKey.getReferencingTable() == table) { // Only check once
                     if (foreignKey.getReferencingIndex() == null) {
-                        output.reportFailure(new AISValidationFailure(new ForeignKeyIndexRequiredException(foreignKey.getConstraintName().getTableName(), foreignKey.getReferencingTable().getName(), foreignKey.getReferencingColumns().toString())));
+                        output.reportFailure(new AISValidationFailure(new ForeignKeyIndexRequiredException(foreignKey.getConstraintName().getTableName(), false, foreignKey.getReferencingTable().getName(), foreignKey.getReferencingColumns().toString())));
                     }
                     if (foreignKey.getReferencedIndex() == null) {
-                        output.reportFailure(new AISValidationFailure(new ForeignKeyIndexRequiredException(foreignKey.getConstraintName().getTableName(), foreignKey.getReferencedTable().getName(), foreignKey.getReferencedColumns().toString())));
+                        output.reportFailure(new AISValidationFailure(new ForeignKeyIndexRequiredException(foreignKey.getConstraintName().getTableName(), true, foreignKey.getReferencedTable().getName(), foreignKey.getReferencedColumns().toString())));
                     }
                 }
             }

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/qp/storeadapter/indexrow/FDBIndexRow.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/qp/storeadapter/indexrow/FDBIndexRow.java
@@ -89,7 +89,8 @@ public class FDBIndexRow extends IndexRow {
             if (indexToHKey.isOrdinal(i)) {
                 // Do nothing, the ValuesHKey should have the correct ordinals
                 // built from the metadata. 
-                assert indexToHKey.getOrdinal(i) == ancestor.ordinals()[segment++];
+                assert indexToHKey.getOrdinal(i) == ancestor.ordinals()[segment];
+                segment++;
             } else {
                 int indexField = indexToHKey.getIndexRowPosition(i);
                 if (index.isSpatial() && indexField > index.firstSpatialArgument()) {

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/error/ForeignKeyIndexRequiredException.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/error/ForeignKeyIndexRequiredException.java
@@ -20,7 +20,12 @@ package com.foundationdb.server.error;
 import com.foundationdb.ais.model.TableName;
 
 public class ForeignKeyIndexRequiredException extends InvalidOperationException {
-    public ForeignKeyIndexRequiredException(String constraintName, TableName tableName, String columnNames) {
-        super(ErrorCode.FOREIGN_KEY_INDEX_REQUIRED, constraintName, tableName.getSchemaName(), tableName.getTableName(), columnNames);
+    public ForeignKeyIndexRequiredException(String constraintName, boolean unique, TableName tableName, String columnNames) {
+        super(ErrorCode.FOREIGN_KEY_INDEX_REQUIRED,
+              constraintName,
+              unique ? "UNIQUE" : "INDEX",
+              tableName.getSchemaName(),
+              tableName.getTableName(),
+              columnNames);
     }
 }

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/service/dxl/BasicDDLFunctions.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/service/dxl/BasicDDLFunctions.java
@@ -729,8 +729,8 @@ public class BasicDDLFunctions implements DDLFunctions {
                 else {
                     throw new NoSuchIndexException(indexName);
                 }
-                // no primary key nor connected to a FK
-                if(index.isPrimaryKey() || index.isConnectedToFK()) {
+                // PRIMARY is special (affects grouping). FOREIGN KEY referenced handled in validations.
+                if(index.isPrimaryKey()) {
                     throw new ProtectedIndexException(indexName, table.getName());
                 }
                 if (allIndexes != tableIndexes) {

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/sql/aisddl/AlterTableDDL.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/sql/aisddl/AlterTableDDL.java
@@ -232,10 +232,6 @@ public class AlterTableDDL {
                                             new NoSuchForeignKeyException(fkNode.getConstraintName().getTableName(), origTable.getName()));
                                 fkNode = null;
                             }
-                            if(fkNode != null) {
-                                // Also drop the referencing index.
-                                indexChanges.add(TableChange.createDrop(fkNode.getConstraintName().getTableName()));
-                            }
                         }
                     }
                     if(fkNode != null) {

--- a/fdb-sql-layer-core/src/main/resources/com/foundationdb/server/error/error_code.properties
+++ b/fdb-sql-layer-core/src/main/resources/com/foundationdb/server/error/error_code.properties
@@ -283,7 +283,7 @@ GENERATOR_WRONG_DATATYPE    = Table `{0}`.`{1}` has column `{2}` with an unsuppo
 
 JOIN_TO_SELF                = Cannot join table `{0}`.`{1}` to itself
 ONLINE_DDL_IN_PROGRESS      = Online DDL in progress for {0}: {1}
-FOREIGN_KEY_INDEX_REQUIRED  = Foreign key `{0}` requires a unique index on `{1}`.`{2}` for columns {3}
+FOREIGN_KEY_INDEX_REQUIRED  = Foreign key `{0}` requires a {1} on `{2}`.`{3}` for columns {4}
 NO_COLUMNS_IN_TABLE         = Table `{0}`.`{1}` must have at least one column
 PROTECTED_COLUMN            = Cannot create or modify column: `{0}`
 CONCURRENT_VIOLATION        = Concurrent violation: {0}

--- a/fdb-sql-layer-core/src/test/java/com/foundationdb/server/service/is/BasicInfoSchemaTablesServiceImplTest.java
+++ b/fdb-sql-layer-core/src/test/java/com/foundationdb/server/service/is/BasicInfoSchemaTablesServiceImplTest.java
@@ -269,6 +269,8 @@ public class BasicInfoSchemaTablesServiceImplTest {
             builder.pk(schema, table);
             builder.indexColumn(schema, table, Index.PRIMARY, "col1", 0, true, null);
             builder.foreignKey(schema, "child", Arrays.asList("col2"), schema, "parent", Arrays.asList("col1"), ForeignKey.Action.RESTRICT, ForeignKey.Action.RESTRICT, true, true, "fkey_parent");
+            builder.index(schema, "child", "fkey_parent");
+            builder.indexColumn(schema, "child", "fkey_parent", "col2", 0, true, null);
             builder.createGroup(table, schema);
             builder.addTableToGroup(table, schema, table);
             

--- a/fdb-sql-layer-core/src/test/java/com/foundationdb/server/test/it/dxl/CreateIndexesIT.java
+++ b/fdb-sql-layer-core/src/test/java/com/foundationdb/server/test/it/dxl/CreateIndexesIT.java
@@ -207,7 +207,6 @@ public final class CreateIndexesIT extends ITBase
         assertNotNull(indexCheck);
         assertFalse(indexCheck.isUnique());
         assertFalse(indexCheck.isPrimaryKey());
-        assertFalse(indexCheck.isConnectedToFK());
         assertEquals("Index count", 1, indexCheck.getKeyColumns().size());
         
         List<Row> rows = scanAllIndex(getTable(tId).getIndex("name"));
@@ -245,7 +244,6 @@ public final class CreateIndexesIT extends ITBase
         assertNotNull(indexCheck);
         assertFalse(indexCheck.isUnique());
         assertFalse(indexCheck.isPrimaryKey());
-        assertFalse(indexCheck.isConnectedToFK());
         assertEquals("Index count", 1, indexCheck.getKeyColumns().size());
         
         // Get all customers
@@ -306,7 +304,6 @@ public final class CreateIndexesIT extends ITBase
         assertNotNull(indexCheck);
         assertTrue(indexCheck.isUnique());
         assertFalse(indexCheck.isPrimaryKey());
-        assertFalse(indexCheck.isConnectedToFK());
         assertEquals("column name: state", "state", indexCheck.getKeyColumns().get(0).getColumn().getName());
         assertEquals("Index count", 1, indexCheck.getKeyColumns().size());
 
@@ -363,7 +360,6 @@ public final class CreateIndexesIT extends ITBase
         assertNotNull(indexCheck);
         assertTrue(indexCheck.isUnique());
         assertFalse(indexCheck.isPrimaryKey());
-        assertFalse(indexCheck.isConnectedToFK());
         assertEquals("column name: otherId", "otherId", indexCheck.getKeyColumns().get(0).getColumn().getName());
         assertEquals("Index count", 1, indexCheck.getKeyColumns().size());
         
@@ -371,7 +367,6 @@ public final class CreateIndexesIT extends ITBase
         assertNotNull(indexCheck2);
         assertFalse(indexCheck2.isUnique());
         assertFalse(indexCheck2.isPrimaryKey());
-        assertFalse(indexCheck2.isConnectedToFK());
         assertEquals("column name: price", "price", indexCheck2.getKeyColumns().get(0).getColumn().getName());
         assertEquals("Index count", 1, indexCheck2.getKeyColumns().size());
         

--- a/fdb-sql-layer-core/src/test/java/com/foundationdb/sql/aisddl/AlterTableDDLTest.java
+++ b/fdb-sql-layer-core/src/test/java/com/foundationdb/sql/aisddl/AlterTableDDLTest.java
@@ -1212,7 +1212,8 @@ public class AlterTableDDLTest {
         builder.table(C_NAME).colBigInt("id", false).pk("id");
         builder.table(A_NAME).colBigInt("id", false).colBigInt("cid").pk("id").uniqueConstraint("cid_unique",
                                                                                                 "cid_unique",
-                                                                                                "cid");
+                                                                                                "cid")
+                                                                              .key("fk_cid", "cid");
         parseAndRun("ALTER TABLE a ADD CONSTRAINT fk_cid FOREIGN KEY (cid) REFERENCES c (id)");
         Table a = ddlFunctions.ais.getTable(A_NAME);
         assertEquals(a.getForeignKeys().size(), 1);

--- a/fdb-sql-layer-core/src/test/resources/com/foundationdb/sql/optimizer/rule/pick-fk-joins/join-fk-4.expected
+++ b/fdb-sql-layer-core/src/test/resources/com/foundationdb/sql/optimizer/rule/pick-fk-joins/join-fk-4.expected
@@ -4,7 +4,7 @@ SelectQuery@7944e589
       Select@662f4d8a[]
         JoinNode@51a6635b(LEFT/NESTED_LOOPS)
           JoinNode@2c5153e(LEFT/NESTED_LOOPS)
-            TableGroupJoinTree@b7d2830(TableGroup@58f59add(animal), animal - SingleIndexScan@648a50cb(Index(test.animal.fk_zoo[IndexColumn(zoo_id)]), NONE, =100, rows = 1, cost = 15.0558))
+            TableGroupJoinTree@b7d2830(TableGroup@58f59add(animal), animal - SingleIndexScan@648a50cb(Index(test.animal.zoo_id[IndexColumn(zoo_id)]), NONE, =100, rows = 1, cost = 15.0558))
               TableSource@19fa8e56(animal - TableGroup@58f59add(animal))
             TableGroupJoinTree@f9fce28(TableGroup@59b2b206(reptile), reptile - ExpressionsHKeyScan@62c5d5eb(TableSource@447bc5da(reptile - TableFKJoin@2a5f69f6(Foreign Key fk_animal_r: test.reptile REFERENCES test.animal)), animal.id, rows = 1, cost = 8.23020))
               TableSource@447bc5da(reptile - TableFKJoin@2a5f69f6(Foreign Key fk_animal_r: test.reptile REFERENCES test.animal))

--- a/fdb-sql-layer-pg/src/main/java/com/foundationdb/sql/pg/PostgresEmulatedMetaDataStatement.java
+++ b/fdb-sql-layer-pg/src/main/java/com/foundationdb/sql/pg/PostgresEmulatedMetaDataStatement.java
@@ -1051,7 +1051,7 @@ public class PostgresEmulatedMetaDataStatement implements PostgresStatement
         Table table = (Table)columnar;
         Map<String,Index> indexes = new TreeMap<>();
         for (Index index : table.getIndexesIncludingInternal()) {
-            if (isAkibanPKIndex(index) || index.isConnectedToFK())
+            if (isAkibanPKIndex(index) || isConnectedToFK(index))
                 continue;
             indexes.put(index.getIndexName().getName(), index);
         }
@@ -1202,7 +1202,7 @@ public class PostgresEmulatedMetaDataStatement implements PostgresStatement
         if (!table.isTable())
             return false;
         for (Index index : ((Table)table).getIndexes()) {
-            if (isAkibanPKIndex(index) || index.isConnectedToFK())
+            if (isAkibanPKIndex(index) || isConnectedToFK(index))
                 continue;
             return true;
         }
@@ -1226,6 +1226,15 @@ public class PostgresEmulatedMetaDataStatement implements PostgresStatement
         List<IndexColumn> indexColumns = index.getKeyColumns();
         return ((indexColumns.size() == 1) && 
                 indexColumns.get(0).getColumn().isAkibanPKColumn());
+    }
+
+    public boolean isConnectedToFK(Index index) {
+        for(ForeignKey fkey : index.leafMostTable().getReferencingForeignKeys()) {
+            if(fkey.getReferencingIndex() == index) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private boolean isTableReferenced(Table table, Index groupIndex) {

--- a/fdb-sql-layer-test-yaml/src/test/resources/com/foundationdb/sql/test/yaml/functional/test-foreign-key-ddl.yaml
+++ b/fdb-sql-layer-test-yaml/src/test/resources/com/foundationdb/sql/test/yaml/functional/test-foreign-key-ddl.yaml
@@ -40,7 +40,7 @@
 - error: [2B001, 'ERROR: Cannot drop table `test`.`t1` due for foreign key constraint `t2_fkey` on `test`.`t2`']
 ---
 - Statement: DROP INDEX t2.`t2_fkey`
-- error: [5000H, 'ERROR: Index `t2_fkey` can not be added or removed from table `test`.`t2`']
+- error: [50032, 'ERROR: Foreign key `t2_fkey` requires a INDEX on `test`.`t2` for columns [t2.pid]']
 ---
 - Statement: ALTER TABLE t1 ALTER COLUMN id SET DATA TYPE BIGINT
 - error: [2B002, 'ERROR: Cannot alter column `id` on `test`.`t1` due for foreign key constraint `t2_fkey`']
@@ -53,7 +53,7 @@
 - CreateTable: t2 (id INT PRIMARY KEY NOT NULL, pid INT, m1 INT, m2 INT)
 ---
 - Statement: ALTER TABLE t2 ADD FOREIGN KEY(m2,m1) REFERENCES t1(n1,n2)
-- error: [50032, 'ERROR: Foreign key `t2_fkey` requires a unique index on `test`.`t1` for columns [n1, n2]']
+- error: [50032, 'ERROR: Foreign key `t2_fkey` requires a UNIQUE on `test`.`t1` for columns [t1.n1, t1.n2]']
 ---
 - Statement: CREATE UNIQUE INDEX t1_n ON t1(n1, n2);
 ---
@@ -146,3 +146,121 @@
 - DropTable: c
 ---
 - DropTable: p
+
+# Index picking and automatic creation on referencing table
+---
+- CreateTable: parent(pid INT PRIMARY KEY)
+
+# Compatible index, exact column
+---
+- CreateTable: child(cid INT PRIMARY KEY, pid INT, INDEX idx(pid), FOREIGN KEY(pid) REFERENCES parent(pid))
+---
+- Statement: SELECT index_name FROM information_schema.indexes WHERE table_schema = CURRENT_SCHEMA AND table_name = 'child'
+- output: [['idx'], ['PRIMARY']]
+---
+- DropTable: child
+
+# Compatible index, extra suffix column
+---
+- CreateTable: child(cid INT PRIMARY KEY, pid INT, x INT, INDEX idx(pid,x), CONSTRAINT fk1 FOREIGN KEY(pid) REFERENCES parent(pid))
+---
+- Statement: SELECT index_name FROM information_schema.indexes WHERE table_schema = CURRENT_SCHEMA AND table_name = 'child'
+- output: [['idx'], ['PRIMARY']]
+
+# Another FK using the same index
+---
+- Statement: ALTER TABLE child ADD CONSTRAINT fk2 FOREIGN KEY(pid) REFERENCES parent(pid)
+---
+- Statement: SELECT index_name FROM information_schema.indexes WHERE table_schema = CURRENT_SCHEMA AND table_name = 'child'
+- output: [['idx'], ['PRIMARY']]
+
+# Another compatible index
+---
+- Statement: CREATE INDEX idx2 ON child(pid)
+
+# Original index
+---
+- Statement: DROP INDEX child.idx
+
+# Now used by both FKs
+---
+- Statement: DROP INDEX child.idx2
+- error: [50032] # Ignore message, could be either FK
+---
+- Statement: ALTER TABLE child DROP FOREIGN KEY fk1
+---
+- Statement: DROP INDEX child.idx2
+- error: [50032, 'ERROR: Foreign key `fk2` requires a INDEX on `test`.`child` for columns [child.pid]']
+---
+- Statement: ALTER TABLE child DROP FOREIGN KEY fk2
+---
+- Statement: DROP INDEX child.idx2
+---
+- DropTable: child
+
+# Compatible index with same name as constraint
+---
+- CreateTable: child(cid INT PRIMARY KEY, pid INT, INDEX fk(pid), CONSTRAINT fk FOREIGN KEY(pid) REFERENCES parent(pid))
+---
+- Statement: SELECT index_name FROM information_schema.indexes WHERE table_schema = CURRENT_SCHEMA AND table_name = 'child'
+- output: [['fk'], ['PRIMARY']]
+---
+- DropTable: child
+
+# Incompatible index with same name as constraint
+---
+- CreateTable: child(cid INT PRIMARY KEY, pid INT, x INT, INDEX fk(x), CONSTRAINT fk FOREIGN KEY(pid) REFERENCES parent(pid))
+---
+- Statement: SELECT index_name FROM information_schema.indexes WHERE table_schema = CURRENT_SCHEMA AND table_name = 'child'
+- output: [['fk'], ['fk$1'], ['PRIMARY']]
+---
+- DropTable: child
+---
+- DropTable: parent
+
+# Compound FK index picking
+---
+- CreateTable: parent(pid INT PRIMARY KEY, p1 INT NOT NULL, p2 INT NOT NULL, UNIQUE(p1, p2))
+
+# Must be unique on exact columns
+---
+- CreateTable: child(cid INT PRIMARY KEY, a INT, CONSTRAINT fk FOREIGN KEY(a) REFERENCES parent(p1))
+- error: [50032, 'ERROR: Foreign key `fk` requires a UNIQUE on `test`.`parent` for columns [parent.p1]']
+
+# Same order as referenced
+---
+- CreateTable: child(cid INT PRIMARY KEY, a INT, b INT, INDEX idx(a,b), FOREIGN KEY(a,b) REFERENCES parent(p1,p2))
+---
+- Statement: SELECT index_name FROM information_schema.indexes WHERE table_schema = CURRENT_SCHEMA AND table_name = 'child'
+- output: [['idx'], ['PRIMARY']]
+---
+- DropTable: child
+
+# Different order as referenced
+---
+- CreateTable: child(cid INT PRIMARY KEY, a INT, b INT, INDEX idx(b,a), FOREIGN KEY(a,b) REFERENCES parent(p2,p1))
+---
+- Statement: SELECT index_name FROM information_schema.indexes WHERE table_schema = CURRENT_SCHEMA AND table_name = 'child'
+- output: [['idx'], ['PRIMARY']]
+---
+- DropTable: child
+
+# Compatible index, different order and trailing columns
+---
+- CreateTable: child(cid INT PRIMARY KEY, a INT, b INT, x INT, INDEX idx(b,a,x), FOREIGN KEY(a,b) REFERENCES parent(p2,p1))
+---
+- Statement: SELECT index_name FROM information_schema.indexes WHERE table_schema = CURRENT_SCHEMA AND table_name = 'child'
+- output: [['idx'], ['PRIMARY']]
+---
+- DropTable: child
+
+# Incompatible index
+---
+- CreateTable: child(cid INT PRIMARY KEY, a INT, b INT, x INT, INDEX idx(x,a,b), CONSTRAINT fk FOREIGN KEY(a,b) REFERENCES parent(p2,p1))
+---
+- Statement: SELECT index_name FROM information_schema.indexes WHERE table_schema = CURRENT_SCHEMA AND table_name = 'child'
+- output: [['fk'], ['idx'], ['PRIMARY']]
+---
+- DropTable: child
+---
+- DropTable: parent

--- a/fdb-sql-layer-test-yaml/src/test/resources/com/foundationdb/sql/test/yaml/functional/test-foreign-key-ddl.yaml
+++ b/fdb-sql-layer-test-yaml/src/test/resources/com/foundationdb/sql/test/yaml/functional/test-foreign-key-ddl.yaml
@@ -264,3 +264,16 @@
 - DropTable: child
 ---
 - DropTable: parent
+
+# INDEX after FOREIGN KEY should not create extra indexes
+---
+- CreateTable: parent(pid INT PRIMARY KEY)
+---
+- CreateTable: child(cid INT PRIMARY KEY, pid INT, CONSTRAINT fk FOREIGN KEY(pid) REFERENCES parent(pid), INDEX idx(pid))
+---
+- Statement: SELECT index_name FROM information_schema.indexes WHERE table_schema = CURRENT_SCHEMA AND table_name = 'child'
+- output: [['idx'], ['PRIMARY']]
+---
+- DropTable: child
+---
+- DropTable: parent


### PR DESCRIPTION
If possible. If not, create and index as before but also ensure it has a unique name.

This avoids creating redundant indexes (e.g. join-fk-4.expected) and avoids an error when the DDL already contains an index of the same name (e.g. migration).

This is implicitly compatible with previously created schemas as the index is looked up at AIS load time, just like referenced side indexes.

Note that now that there is no longer a 1-1 mapping any index that was implicitly created is no longer dropped if the FK is dropped. We could mark such indexes but that keeping them actually seems pretty reasonable from a query plan predictability standpoint.