### PR TITLE
Monitor service monitor more stats

### DIFF
--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/service/is/ServerSchemaTablesServiceImpl.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/service/is/ServerSchemaTablesServiceImpl.java
@@ -287,14 +287,10 @@ public class ServerSchemaTablesServiceImpl
                         monitor.getCount(StatementTypes.FROM_CACHE),
                         monitor.getCount(StatementTypes.LOGGED),
                         monitor.getCount(StatementTypes.CALL_STMT),
-                        monitor.getCount(StatementTypes.COPY_STMT),
                         monitor.getCount(StatementTypes.DDL_STMT),
                         monitor.getCount(StatementTypes.DML_STMT),
-                        monitor.getCount(StatementTypes.EXPLAIN),
-                        monitor.getCount(StatementTypes.METADATA),
                         monitor.getCount(StatementTypes.SELECT),
-                        monitor.getCount(StatementTypes.SESSION),
-                        monitor.getCount(StatementTypes.SERVER),
+                        monitor.getCount(StatementTypes.OTHER_STMT),
                         ++rowCounter);
             }
         }
@@ -347,14 +343,10 @@ public class ServerSchemaTablesServiceImpl
                                               session.getCount(StatementTypes.FROM_CACHE),
                                               session.getCount(StatementTypes.LOGGED),
                                               session.getCount(StatementTypes.CALL_STMT),
-                                              session.getCount(StatementTypes.COPY_STMT),
                                               session.getCount(StatementTypes.DDL_STMT),
                                               session.getCount(StatementTypes.DML_STMT),
-                                              session.getCount(StatementTypes.EXPLAIN),
-                                              session.getCount(StatementTypes.METADATA),
                                               session.getCount(StatementTypes.SELECT),
-                                              session.getCount(StatementTypes.SESSION),
-                                              session.getCount(StatementTypes.SERVER),
+                                              session.getCount(StatementTypes.OTHER_STMT),
                                               ++rowCounter);
             }
         }
@@ -749,14 +741,10 @@ public class ServerSchemaTablesServiceImpl
             .colBigInt("query_from_cache", false)
             .colBigInt("logged_statements", false)
             .colBigInt("call_statement_count", false)
-            .colBigInt("copy_statement_count", false)
             .colBigInt("ddl_statment_count", false)
             .colBigInt("dml_statement_count", false)
-            .colBigInt("explain_statement_count", false)
-            .colBigInt("metadata_statement_count", false)
             .colBigInt("select_statement_count", false)
-            .colBigInt("session_statement_count", false)
-            .colBigInt("server_statement_count", false)
+            .colBigInt("other_statement_count", false)
             ;
         
         builder.table(SERVER_SESSIONS)
@@ -775,15 +763,12 @@ public class ServerSchemaTablesServiceImpl
             .colBigInt("failed_query_count", false)
             .colBigInt("query_from_cache", false)
             .colBigInt("logged_statements", false)
+
             .colBigInt("call_statement_count", false)
-            .colBigInt("copy_statement_count", false)
             .colBigInt("ddl_statment_count", false)
             .colBigInt("dml_statement_count", false)
-            .colBigInt("explain_statement_count", false)
-            .colBigInt("metadata_statement_count", false)
             .colBigInt("select_statement_count", false)
-            .colBigInt("session_statement_count", false)
-            .colBigInt("server_statement_count", false)
+            .colBigInt("other_statement_count", false)
             ;
         
         builder.table(ERROR_CODES)

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/service/is/ServerSchemaTablesServiceImpl.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/service/is/ServerSchemaTablesServiceImpl.java
@@ -50,6 +50,7 @@ import com.foundationdb.server.service.monitor.PreparedStatementMonitor;
 import com.foundationdb.server.service.monitor.ServerMonitor;
 import com.foundationdb.server.service.monitor.SessionMonitor;
 import com.foundationdb.server.service.monitor.UserMonitor;
+import com.foundationdb.server.service.monitor.SessionMonitor.StatementTypes;
 import com.foundationdb.server.service.security.SecurityService;
 import com.foundationdb.server.service.session.Session;
 import com.foundationdb.server.store.SchemaManager;
@@ -288,12 +289,23 @@ public class ServerSchemaTablesServiceImpl
                                               session.getRemoteAddress(),
                                               (stage == null) ? null : stage.name(),
                                               (long)session.getStatementCount(),
-                                              (long)session.getFailedStatementCount(),
                                               session.getCurrentStatement(),
                                               session.getCurrentStatementStartTimeMillis() > 0 ? (int)(session.getCurrentStatementStartTimeMillis() / 1000) : null,
                                               session.getCurrentStatementEndTimeMillis() > 0 ? (int)(session.getCurrentStatementEndTimeMillis()/1000) : null,
                                               session.getRowsProcessed() < 0 ? null : (long)session.getRowsProcessed(),
                                               session.getCurrentStatementPreparedName(),
+                                              session.getCount(StatementTypes.FAILED),
+                                              session.getCount(StatementTypes.FROM_CACHE),
+                                              session.getCount(StatementTypes.LOGGED),
+                                              session.getCount(StatementTypes.CALL_STMT),
+                                              session.getCount(StatementTypes.COPY_STMT),
+                                              session.getCount(StatementTypes.DDL_STMT),
+                                              session.getCount(StatementTypes.DML_STMT),
+                                              session.getCount(StatementTypes.EXPLAIN),
+                                              session.getCount(StatementTypes.METADATA),
+                                              session.getCount(StatementTypes.SELECT),
+                                              session.getCount(StatementTypes.SESSION),
+                                              session.getCount(StatementTypes.SERVER),
                                               ++rowCounter);
             }
         }
@@ -690,12 +702,24 @@ public class ServerSchemaTablesServiceImpl
             .colString("remote_address", DESCRIPTOR_MAX, true)
             .colString("session_status", DESCRIPTOR_MAX, true)
             .colBigInt("query_count", false)
-            .colBigInt("failed_query_count", false)
             .colString("last_query_executed", PATH_MAX, true)
             .colSystemTimestamp("query_start_time", true)
             .colSystemTimestamp("query_end_time", true)
             .colBigInt("query_row_count", true)
-            .colString("prepared_name", IDENT_MAX, true);
+            .colString("prepared_name", IDENT_MAX, true)
+            .colBigInt("failed_query_count", false)
+            .colBigInt("query_from_cache", false)
+            .colBigInt("logged_statements", false)
+            .colBigInt("call_statement_count", false)
+            .colBigInt("copy_statement_count", false)
+            .colBigInt("ddl_statment_count", false)
+            .colBigInt("dml_statement_count", false)
+            .colBigInt("explain_statement_count", false)
+            .colBigInt("metadata_statement_count", false)
+            .colBigInt("select_statement_count", false)
+            .colBigInt("session_statement_count", false)
+            .colBigInt("server_statement_count", false)
+            ;
         
         builder.table(ERROR_CODES)
             .colString("code", 5, false)

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/service/is/ServerSchemaTablesServiceImpl.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/service/is/ServerSchemaTablesServiceImpl.java
@@ -288,6 +288,7 @@ public class ServerSchemaTablesServiceImpl
                                               session.getRemoteAddress(),
                                               (stage == null) ? null : stage.name(),
                                               (long)session.getStatementCount(),
+                                              (long)session.getFailedStatementCount(),
                                               session.getCurrentStatement(),
                                               session.getCurrentStatementStartTimeMillis() > 0 ? (int)(session.getCurrentStatementStartTimeMillis() / 1000) : null,
                                               session.getCurrentStatementEndTimeMillis() > 0 ? (int)(session.getCurrentStatementEndTimeMillis()/1000) : null,
@@ -689,6 +690,7 @@ public class ServerSchemaTablesServiceImpl
             .colString("remote_address", DESCRIPTOR_MAX, true)
             .colString("session_status", DESCRIPTOR_MAX, true)
             .colBigInt("query_count", false)
+            .colBigInt("failed_query_count", false)
             .colString("last_query_executed", PATH_MAX, true)
             .colSystemTimestamp("query_start_time", true)
             .colSystemTimestamp("query_end_time", true)

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/service/monitor/MonitorService.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/service/monitor/MonitorService.java
@@ -17,6 +17,7 @@
 
 package com.foundationdb.server.service.monitor;
 
+import com.foundationdb.server.service.monitor.SessionMonitor.StatementTypes;
 import com.foundationdb.server.service.session.Session;
 
 import java.util.Collection;
@@ -73,6 +74,10 @@ public interface MonitorService {
     
     /** Get all the user monitors. */
     Collection<UserMonitor> getUserMonitors();
+
+    /** Get statisics counter for statement types */
+    long getCount(StatementTypes type);
+    
 
     //
     // Query Log Control

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/service/monitor/MonitorServiceImpl.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/service/monitor/MonitorServiceImpl.java
@@ -20,7 +20,6 @@ package com.foundationdb.server.service.monitor;
 import com.foundationdb.server.error.QueryLogCloseException;
 import com.foundationdb.server.service.Service;
 import com.foundationdb.server.service.config.ConfigurationService;
-import com.foundationdb.server.service.jmx.JmxManageable;
 import com.foundationdb.server.service.session.Session;
 
 import com.google.inject.Inject;
@@ -35,7 +34,6 @@ import java.sql.Timestamp;
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class MonitorServiceImpl implements Service, MonitorService
@@ -157,6 +155,8 @@ public class MonitorServiceImpl implements Service, MonitorService
         if (queryLogThresholdMillis > 0 && duration < queryLogThresholdMillis) {
             return;
         }
+        
+        
         /*
          * format of each query log entry is:
          * #

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/service/monitor/MonitorServiceImpl.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/service/monitor/MonitorServiceImpl.java
@@ -20,9 +20,10 @@ package com.foundationdb.server.service.monitor;
 import com.foundationdb.server.error.QueryLogCloseException;
 import com.foundationdb.server.service.Service;
 import com.foundationdb.server.service.config.ConfigurationService;
+import com.foundationdb.server.service.monitor.SessionMonitor.StatementTypes;
 import com.foundationdb.server.service.session.Session;
-
 import com.google.inject.Inject;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -156,7 +157,8 @@ public class MonitorServiceImpl implements Service, MonitorService
             return;
         }
         
-        
+        SessionMonitor monitor = sessions.get(sessionId);
+        monitor.countEvent(StatementTypes.LOGGED);
         /*
          * format of each query log entry is:
          * #

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/service/monitor/SessionEventListener.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/service/monitor/SessionEventListener.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (C) 2009-2013 FoundationDB, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.foundationdb.server.service.monitor;
+
+import java.util.EventListener;
+
+import com.foundationdb.server.service.monitor.SessionMonitor.StatementTypes;
+
+public interface SessionEventListener extends EventListener{
+
+    public void countEvent (StatementTypes type);
+}

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/service/monitor/SessionEventListener.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/service/monitor/SessionEventListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2009-2013 FoundationDB, LLC
+ * Copyright (C) 2009-2015 FoundationDB, LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/service/monitor/SessionMonitor.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/service/monitor/SessionMonitor.java
@@ -36,10 +36,13 @@ public interface SessionMonitor {
     long getStartTimeMillis();
     
     /** The number of queries executed. */
-    int getStatementCount();
+    long getStatementCount();
 
-    /** The number of queries that failed. */
-    int getFailedStatementCount();
+    /** Get number of statements executes of a given type */
+    long getCount(StatementTypes type);
+    
+    /** Count an statement execution */
+    void countEvent(StatementTypes type);
     
     /** The SQL of the current / last statement. */
     String getCurrentStatement();    
@@ -82,4 +85,31 @@ public interface SessionMonitor {
     
     /** Get the user monitor for this session */
     UserMonitor getUserMonitor();
+
+    public enum StatementTypes {
+        STATEMENT  ("statement"),
+        FAILED     ("failed statement"),
+        FROM_CACHE ("Statement from cache"),
+        LOGGED     ("Statment logged"),
+        CALL_STMT  ("call statement"),
+        COPY_STMT  ("copy statement"),
+        DDL_STMT   ("DDL statement"),
+        DML_STMT   ("DML statement"),
+        EXPLAIN    ("Explain statement"),
+        METADATA   ("Metadata statement"),
+        SELECT     ("Select statement"),
+        SESSION    ("Session statement"),
+        SERVER     ("Server statement");
+        
+        private StatementTypes (String name) {
+            this.name = name;
+        }
+        private String name; 
+        
+        public String toString() {
+            return name;
+        }
+    }
+
+
 }

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/service/monitor/SessionMonitor.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/service/monitor/SessionMonitor.java
@@ -38,6 +38,9 @@ public interface SessionMonitor {
     /** The number of queries executed. */
     int getStatementCount();
 
+    /** The number of queries that failed. */
+    int getFailedStatementCount();
+    
     /** The SQL of the current / last statement. */
     String getCurrentStatement();    
 

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/service/monitor/SessionMonitor.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/service/monitor/SessionMonitor.java
@@ -86,13 +86,17 @@ public interface SessionMonitor {
     /** Get the user monitor for this session */
     UserMonitor getUserMonitor();
 
+    public void addSessionEventListener(SessionEventListener listener);
+    public void removeSessionEventListener (SessionEventListener listener);
+    
+    
     public enum StatementTypes {
-        STATEMENT  ("statement"),
-        FAILED     ("failed statement"),
+        STATEMENT  ("Statement"),
+        FAILED     ("Failed statement"),
         FROM_CACHE ("Statement from cache"),
         LOGGED     ("Statment logged"),
-        CALL_STMT  ("call statement"),
-        COPY_STMT  ("copy statement"),
+        CALL_STMT  ("Call statement"),
+        COPY_STMT  ("Copy statement"),
         DDL_STMT   ("DDL statement"),
         DML_STMT   ("DML statement"),
         EXPLAIN    ("Explain statement"),

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/service/monitor/SessionMonitor.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/service/monitor/SessionMonitor.java
@@ -91,29 +91,15 @@ public interface SessionMonitor {
     
     
     public enum StatementTypes {
-        STATEMENT  ("Statement"),
-        FAILED     ("Failed statement"),
-        FROM_CACHE ("Statement from cache"),
-        LOGGED     ("Statment logged"),
-        CALL_STMT  ("Call statement"),
-        COPY_STMT  ("Copy statement"),
-        DDL_STMT   ("DDL statement"),
-        DML_STMT   ("DML statement"),
-        EXPLAIN    ("Explain statement"),
-        METADATA   ("Metadata statement"),
-        SELECT     ("Select statement"),
-        SESSION    ("Session statement"),
-        SERVER     ("Server statement");
+        STATEMENT,
+        FAILED ,
+        FROM_CACHE,
+        LOGGED,
         
-        private StatementTypes (String name) {
-            this.name = name;
-        }
-        private String name; 
-        
-        public String toString() {
-            return name;
-        }
+        CALL_STMT,
+        DDL_STMT,
+        DML_STMT,
+        SELECT,
+        OTHER_STMT;
     }
-
-
 }

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/service/monitor/SessionMonitorBase.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/service/monitor/SessionMonitorBase.java
@@ -32,6 +32,7 @@ public abstract class SessionMonitorBase implements SessionMonitor {
     private long currentStatementEndTime = -1;
     private int rowsProcessed = 0;
     private int statementCount = 0;
+    private int failedStatementCount = 0;
     private UserMonitor user = null; 
 
     protected SessionMonitorBase(int sessionID) {
@@ -70,6 +71,11 @@ public abstract class SessionMonitorBase implements SessionMonitor {
             user.statementRun();
         }
     }
+    
+    public void failStatement() {
+        failedStatementCount++;
+        endStatement(-1);
+    }
 
     // Caller can sequence all stages and avoid any gaps at the cost of more complicated
     // exception handling, or just enter & leave and accept a tiny bit
@@ -105,6 +111,11 @@ public abstract class SessionMonitorBase implements SessionMonitor {
     @Override
     public int getStatementCount() {
         return statementCount;
+    }
+    
+    @Override
+    public int getFailedStatementCount() {
+        return failedStatementCount;
     }
 
     @Override

--- a/fdb-sql-layer-core/src/test/java/com/foundationdb/server/service/is/ServerSchemaTablesServiceIT.java
+++ b/fdb-sql-layer-core/src/test/java/com/foundationdb/server/service/is/ServerSchemaTablesServiceIT.java
@@ -71,12 +71,13 @@ public class ServerSchemaTablesServiceIT extends ITBase
     @Test
     public void examine() {
         AkibanInformationSchema ais = ais();
-        assertEquals ("Table count", 12, ServerSchemaTablesServiceImpl.createTablesToRegister(ddl().getTypesTranslator()).getTables().size());
+        assertEquals ("Table count", 13, ServerSchemaTablesServiceImpl.createTablesToRegister(ddl().getTypesTranslator()).getTables().size());
         assertNotNull (ais.getTable(ServerSchemaTablesServiceImpl.ERROR_CODES));
         assertNotNull (ais.getTable(ServerSchemaTablesServiceImpl.ERROR_CODE_CLASSES));
         assertNotNull (ais.getTable(ServerSchemaTablesServiceImpl.SERVER_INSTANCE_SUMMARY));
         assertNotNull (ais.getTable(ServerSchemaTablesServiceImpl.SERVER_SERVERS));
         assertNotNull (ais.getTable(ServerSchemaTablesServiceImpl.SERVER_SESSIONS));
+        assertNotNull (ais.getTable(ServerSchemaTablesServiceImpl.SERVER_STATISTICS));
         assertNotNull (ais.getTable(ServerSchemaTablesServiceImpl.SERVER_PARAMETERS));
         assertNotNull (ais.getTable(ServerSchemaTablesServiceImpl.SERVER_MEMORY_POOLS));
         assertNotNull (ais.getTable(ServerSchemaTablesServiceImpl.SERVER_GARBAGE_COLLECTORS));
@@ -144,6 +145,13 @@ public class ServerSchemaTablesServiceIT extends ITBase
         final Object[][] expected = {
         };
         checkLimitTable (expected, ServerSchemaTablesServiceImpl.SERVER_SESSIONS, 0);
+    }
+    
+    @Test
+    public void testServerStatistics() {
+        final Object[][] expected = {
+        };
+        checkLimitTable (expected, ServerSchemaTablesServiceImpl.SERVER_STATISTICS, 0);
     }
     
     @Test

--- a/fdb-sql-layer-pg/src/main/java/com/foundationdb/sql/pg/PostgresBaseCursorStatement.java
+++ b/fdb-sql-layer-pg/src/main/java/com/foundationdb/sql/pg/PostgresBaseCursorStatement.java
@@ -17,6 +17,8 @@
 
 package com.foundationdb.sql.pg;
 
+import com.foundationdb.server.service.monitor.SessionMonitor;
+import com.foundationdb.server.service.monitor.SessionMonitor.StatementTypes;
 import com.foundationdb.sql.optimizer.plan.CostEstimate;
 
 import java.io.IOException;
@@ -81,5 +83,4 @@ public abstract class PostgresBaseCursorStatement implements PostgresStatement
     public CostEstimate getCostEstimate() {
         return null;
     }
-
 }

--- a/fdb-sql-layer-pg/src/main/java/com/foundationdb/sql/pg/PostgresCopyInStatement.java
+++ b/fdb-sql-layer-pg/src/main/java/com/foundationdb/sql/pg/PostgresCopyInStatement.java
@@ -30,6 +30,7 @@ import com.foundationdb.server.error.NoSuchTableException;
 import com.foundationdb.server.error.UnsupportedSQLException;
 import com.foundationdb.server.service.externaldata.CsvFormat;
 import com.foundationdb.server.service.externaldata.ExternalDataService;
+import com.foundationdb.server.service.monitor.SessionMonitor.StatementTypes;
 import com.foundationdb.server.service.session.Session;
 import com.foundationdb.sql.server.ServerTransaction;
 import com.foundationdb.util.tap.InOutTap;
@@ -138,6 +139,7 @@ public class PostgresCopyInStatement extends PostgresBaseStatement
     @Override
     public int execute(PostgresQueryContext context, QueryBindings bindings, int maxrows) throws IOException {
         PostgresServerSession server = context.getServer();
+        server.getSessionMonitor().countEvent(StatementTypes.COPY_STMT);
         Session session = server.getSession();
         ExternalDataService externalData = server.getExternalDataService();
         InputStream istr;

--- a/fdb-sql-layer-pg/src/main/java/com/foundationdb/sql/pg/PostgresCopyInStatement.java
+++ b/fdb-sql-layer-pg/src/main/java/com/foundationdb/sql/pg/PostgresCopyInStatement.java
@@ -139,7 +139,7 @@ public class PostgresCopyInStatement extends PostgresBaseStatement
     @Override
     public int execute(PostgresQueryContext context, QueryBindings bindings, int maxrows) throws IOException {
         PostgresServerSession server = context.getServer();
-        server.getSessionMonitor().countEvent(StatementTypes.COPY_STMT);
+        server.getSessionMonitor().countEvent(StatementTypes.OTHER_STMT);
         Session session = server.getSession();
         ExternalDataService externalData = server.getExternalDataService();
         InputStream istr;

--- a/fdb-sql-layer-pg/src/main/java/com/foundationdb/sql/pg/PostgresCopyOutStatement.java
+++ b/fdb-sql-layer-pg/src/main/java/com/foundationdb/sql/pg/PostgresCopyOutStatement.java
@@ -83,7 +83,7 @@ public class PostgresCopyOutStatement extends PostgresOperatorStatement
             return super.execute(context, bindings, maxrows);
 
         PostgresServerSession server = context.getServer();
-        server.getSessionMonitor().countEvent(StatementTypes.COPY_STMT);
+        server.getSessionMonitor().countEvent(StatementTypes.OTHER_STMT);
         int nrows = 0;
         Cursor cursor = null;
         OutputStream outputStream = null;

--- a/fdb-sql-layer-pg/src/main/java/com/foundationdb/sql/pg/PostgresCopyOutStatement.java
+++ b/fdb-sql-layer-pg/src/main/java/com/foundationdb/sql/pg/PostgresCopyOutStatement.java
@@ -21,13 +21,13 @@ import com.foundationdb.sql.StandardException;
 import com.foundationdb.sql.parser.CopyStatementNode;
 import com.foundationdb.sql.parser.ParameterNode;
 import com.foundationdb.sql.parser.StatementNode;
-
 import com.foundationdb.qp.operator.Cursor;
 import com.foundationdb.qp.operator.QueryBindings;
 import com.foundationdb.qp.row.Row;
 import com.foundationdb.server.error.SQLParserInternalException;
 import com.foundationdb.server.error.UnsupportedSQLException;
 import com.foundationdb.server.service.externaldata.CsvFormat;
+import com.foundationdb.server.service.monitor.SessionMonitor.StatementTypes;
 
 import static com.foundationdb.sql.pg.PostgresCopyInStatement.csvFormat;
 import static com.foundationdb.server.service.dxl.DXLFunctionsHook.DXLFunction;
@@ -83,6 +83,7 @@ public class PostgresCopyOutStatement extends PostgresOperatorStatement
             return super.execute(context, bindings, maxrows);
 
         PostgresServerSession server = context.getServer();
+        server.getSessionMonitor().countEvent(StatementTypes.COPY_STMT);
         int nrows = 0;
         Cursor cursor = null;
         OutputStream outputStream = null;

--- a/fdb-sql-layer-pg/src/main/java/com/foundationdb/sql/pg/PostgresDDLStatement.java
+++ b/fdb-sql-layer-pg/src/main/java/com/foundationdb/sql/pg/PostgresDDLStatement.java
@@ -18,13 +18,12 @@
 package com.foundationdb.sql.pg;
 
 import com.foundationdb.server.api.DDLFunctions;
+import com.foundationdb.server.service.monitor.SessionMonitor.StatementTypes;
 import com.foundationdb.server.service.session.Session;
 import com.foundationdb.sql.aisddl.AISDDL;
 import com.foundationdb.sql.aisddl.TableDDL;
 import com.foundationdb.sql.parser.*;
-
 import com.foundationdb.qp.operator.QueryBindings;
-
 import com.foundationdb.sql.types.DataTypeDescriptor;
 import com.foundationdb.util.tap.InOutTap;
 import com.foundationdb.util.tap.Tap;
@@ -122,6 +121,7 @@ public class PostgresDDLStatement extends PostgresBaseStatement
     @Override
     public int execute(PostgresQueryContext context, QueryBindings bindings, int maxrows) throws IOException {
         PostgresServerSession server = context.getServer();
+        server.getSessionMonitor().countEvent(StatementTypes.DDL_STMT);
         PostgresMessenger messenger = server.getMessenger();
         //if this is a create table node with a query expression use special case
         if(ddl.getNodeType() == NodeTypes.CREATE_TABLE_NODE && ((CreateTableNode)ddl).getQueryExpression() != null){

--- a/fdb-sql-layer-pg/src/main/java/com/foundationdb/sql/pg/PostgresEmulatedMetaDataStatement.java
+++ b/fdb-sql-layer-pg/src/main/java/com/foundationdb/sql/pg/PostgresEmulatedMetaDataStatement.java
@@ -516,7 +516,7 @@ public class PostgresEmulatedMetaDataStatement implements PostgresStatement
     @Override
     public int execute(PostgresQueryContext context, QueryBindings bindings, int maxrows) throws IOException {
         PostgresServerSession server = context.getServer();
-        server.getSessionMonitor().countEvent(StatementTypes.METADATA);
+        server.getSessionMonitor().countEvent(StatementTypes.OTHER_STMT);
         PostgresMessenger messenger = server.getMessenger();
         int nrows = 0;
         switch (query) {

--- a/fdb-sql-layer-pg/src/main/java/com/foundationdb/sql/pg/PostgresEmulatedMetaDataStatement.java
+++ b/fdb-sql-layer-pg/src/main/java/com/foundationdb/sql/pg/PostgresEmulatedMetaDataStatement.java
@@ -19,6 +19,7 @@ package com.foundationdb.sql.pg;
 
 import com.foundationdb.ais.model.*;
 import com.foundationdb.qp.operator.QueryBindings;
+import com.foundationdb.server.service.monitor.SessionMonitor.StatementTypes;
 import com.foundationdb.server.types.common.types.TypesTranslator;
 import com.foundationdb.sql.optimizer.plan.CostEstimate;
 import com.foundationdb.sql.parser.ParameterNode;
@@ -515,6 +516,7 @@ public class PostgresEmulatedMetaDataStatement implements PostgresStatement
     @Override
     public int execute(PostgresQueryContext context, QueryBindings bindings, int maxrows) throws IOException {
         PostgresServerSession server = context.getServer();
+        server.getSessionMonitor().countEvent(StatementTypes.METADATA);
         PostgresMessenger messenger = server.getMessenger();
         int nrows = 0;
         switch (query) {

--- a/fdb-sql-layer-pg/src/main/java/com/foundationdb/sql/pg/PostgresEmulatedSessionStatement.java
+++ b/fdb-sql-layer-pg/src/main/java/com/foundationdb/sql/pg/PostgresEmulatedSessionStatement.java
@@ -18,6 +18,7 @@
 package com.foundationdb.sql.pg;
 
 import com.foundationdb.qp.operator.QueryBindings;
+import com.foundationdb.server.service.monitor.SessionMonitor.StatementTypes;
 import com.foundationdb.sql.optimizer.plan.CostEstimate;
 import com.foundationdb.sql.parser.ParameterNode;
 import com.foundationdb.sql.parser.StatementNode;
@@ -89,6 +90,7 @@ public class PostgresEmulatedSessionStatement implements PostgresStatement
     @Override
     public int execute(PostgresQueryContext context, QueryBindings bindings, int maxrows) throws IOException {
         PostgresServerSession server = context.getServer();
+        server.getSessionMonitor().countEvent(StatementTypes.SESSION);
         doOperation(context, server);
         {        
             PostgresMessenger messenger = server.getMessenger();

--- a/fdb-sql-layer-pg/src/main/java/com/foundationdb/sql/pg/PostgresEmulatedSessionStatement.java
+++ b/fdb-sql-layer-pg/src/main/java/com/foundationdb/sql/pg/PostgresEmulatedSessionStatement.java
@@ -90,7 +90,7 @@ public class PostgresEmulatedSessionStatement implements PostgresStatement
     @Override
     public int execute(PostgresQueryContext context, QueryBindings bindings, int maxrows) throws IOException {
         PostgresServerSession server = context.getServer();
-        server.getSessionMonitor().countEvent(StatementTypes.SESSION);
+        server.getSessionMonitor().countEvent(StatementTypes.OTHER_STMT);
         doOperation(context, server);
         {        
             PostgresMessenger messenger = server.getMessenger();

--- a/fdb-sql-layer-pg/src/main/java/com/foundationdb/sql/pg/PostgresExplainStatement.java
+++ b/fdb-sql-layer-pg/src/main/java/com/foundationdb/sql/pg/PostgresExplainStatement.java
@@ -28,12 +28,11 @@ import com.foundationdb.sql.parser.ExplainStatementNode;
 import com.foundationdb.sql.parser.ParameterNode;
 import com.foundationdb.sql.parser.StatementNode;
 import com.foundationdb.sql.server.ServerValueEncoder;
-
 import com.foundationdb.qp.operator.QueryBindings;
-
 import com.foundationdb.server.explain.Explainable;
 import com.foundationdb.server.explain.format.DefaultFormatter;
 import com.foundationdb.server.explain.format.JsonFormatter;
+import com.foundationdb.server.service.monitor.SessionMonitor.StatementTypes;
 import com.foundationdb.server.types.TClass;
 
 import java.util.Collections;
@@ -115,6 +114,7 @@ public class PostgresExplainStatement implements PostgresStatement
     @Override
     public int execute(PostgresQueryContext context, QueryBindings bindings, int maxrows) throws IOException {
         PostgresServerSession server = context.getServer();
+        server.getSessionMonitor().countEvent(StatementTypes.EXPLAIN);
         PostgresMessenger messenger = server.getMessenger();
         ServerValueEncoder encoder = server.getValueEncoder();
         int nrows = 0;

--- a/fdb-sql-layer-pg/src/main/java/com/foundationdb/sql/pg/PostgresExplainStatement.java
+++ b/fdb-sql-layer-pg/src/main/java/com/foundationdb/sql/pg/PostgresExplainStatement.java
@@ -114,7 +114,7 @@ public class PostgresExplainStatement implements PostgresStatement
     @Override
     public int execute(PostgresQueryContext context, QueryBindings bindings, int maxrows) throws IOException {
         PostgresServerSession server = context.getServer();
-        server.getSessionMonitor().countEvent(StatementTypes.EXPLAIN);
+        server.getSessionMonitor().countEvent(StatementTypes.OTHER_STMT);
         PostgresMessenger messenger = server.getMessenger();
         ServerValueEncoder encoder = server.getValueEncoder();
         int nrows = 0;

--- a/fdb-sql-layer-pg/src/main/java/com/foundationdb/sql/pg/PostgresJavaRoutine.java
+++ b/fdb-sql-layer-pg/src/main/java/com/foundationdb/sql/pg/PostgresJavaRoutine.java
@@ -24,13 +24,13 @@ import static com.foundationdb.sql.pg.PostgresJsonStatement.jsonAISColumns;
 import com.foundationdb.sql.parser.ParameterNode;
 import com.foundationdb.sql.server.ServerCallInvocation;
 import com.foundationdb.sql.server.ServerJavaRoutine;
-
 import com.foundationdb.ais.model.Column;
 import com.foundationdb.ais.model.Parameter;
 import com.foundationdb.ais.model.Routine;
 import com.foundationdb.qp.operator.QueryBindings;
 import com.foundationdb.server.error.ExternalRoutineInvocationException;
 import com.foundationdb.server.explain.Explainable;
+import com.foundationdb.server.service.monitor.SessionMonitor.StatementTypes;
 import com.foundationdb.util.tap.InOutTap;
 import com.foundationdb.util.tap.Tap;
 
@@ -143,6 +143,7 @@ public abstract class PostgresJavaRoutine extends PostgresDMLStatement
     @Override
     public int execute(PostgresQueryContext context, QueryBindings bindings, int maxrows) throws IOException {
         PostgresServerSession server = context.getServer();
+        server.getSessionMonitor().countEvent(StatementTypes.CALL_STMT);
         PostgresMessenger messenger = server.getMessenger();
         int nrows = 0;
         Queue<ResultSet> dynamicResultSets = null;

--- a/fdb-sql-layer-pg/src/main/java/com/foundationdb/sql/pg/PostgresModifyOperatorStatement.java
+++ b/fdb-sql-layer-pg/src/main/java/com/foundationdb/sql/pg/PostgresModifyOperatorStatement.java
@@ -26,12 +26,14 @@ import com.foundationdb.qp.operator.QueryBindings;
 import com.foundationdb.qp.row.Row;
 import com.foundationdb.qp.rowtype.RowType;
 import com.foundationdb.server.service.dxl.DXLFunctionsHook.DXLFunction;
+import com.foundationdb.server.service.monitor.SessionMonitor.StatementTypes;
 
 import java.io.IOException;
 import java.util.List;
 
 import com.foundationdb.util.tap.InOutTap;
 import com.foundationdb.util.tap.Tap;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -131,6 +133,7 @@ public class PostgresModifyOperatorStatement extends PostgresBaseOperatorStateme
     @Override
     public int execute(PostgresQueryContext context, QueryBindings bindings, int maxrows) throws IOException {
         PostgresServerSession server = context.getServer();
+        server.getSessionMonitor().countEvent(StatementTypes.DML_STMT);
         PostgresMessenger messenger = server.getMessenger();
         int rowsModified = 0;
         if (resultOperator != null) {

--- a/fdb-sql-layer-pg/src/main/java/com/foundationdb/sql/pg/PostgresOperatorStatement.java
+++ b/fdb-sql-layer-pg/src/main/java/com/foundationdb/sql/pg/PostgresOperatorStatement.java
@@ -19,6 +19,7 @@ package com.foundationdb.sql.pg;
 
 import com.foundationdb.ais.model.Column;
 import com.foundationdb.server.error.InvalidOperationException;
+import com.foundationdb.server.service.monitor.SessionMonitor.StatementTypes;
 import com.foundationdb.sql.optimizer.plan.CostEstimate;
 import com.foundationdb.qp.operator.*;
 import com.foundationdb.qp.row.Row;
@@ -99,6 +100,7 @@ public class PostgresOperatorStatement extends PostgresBaseOperatorStatement
     @Override
     public int execute(PostgresQueryContext context, QueryBindings bindings, int maxrows) throws IOException {
         PostgresServerSession server = context.getServer();
+        server.getSessionMonitor().countEvent(StatementTypes.SELECT);
         PostgresMessenger messenger = server.getMessenger();
         int nrows = 0;
         Cursor cursor = null;

--- a/fdb-sql-layer-pg/src/main/java/com/foundationdb/sql/pg/PostgresServerConnection.java
+++ b/fdb-sql-layer-pg/src/main/java/com/foundationdb/sql/pg/PostgresServerConnection.java
@@ -384,7 +384,7 @@ public class PostgresServerConnection extends ServerSessionBase
             // Current statement did not complete, include in error message.
             sql = sessionMonitor.getCurrentStatement();
             if (sql != null) {
-                sessionMonitor.endStatement(-1); // For system tables and for next time.
+                sessionMonitor.failStatement(); // For system tables and for next time.
                 if(reqs.monitor().isQueryLogEnabled() && ex instanceof InvalidOperationException){
                     for(ErrorCode slowError : slowErrors) {
                         if (((InvalidOperationException) ex).getCode() == slowError) {

--- a/fdb-sql-layer-pg/src/main/java/com/foundationdb/sql/pg/PostgresServerConnection.java
+++ b/fdb-sql-layer-pg/src/main/java/com/foundationdb/sql/pg/PostgresServerConnection.java
@@ -25,12 +25,10 @@ import com.foundationdb.sql.server.ServerStatement;
 import com.foundationdb.sql.server.ServerStatementCache;
 import com.foundationdb.sql.server.ServerValueDecoder;
 import com.foundationdb.sql.server.ServerValueEncoder;
-
 import com.foundationdb.sql.StandardException;
 import com.foundationdb.sql.parser.ParameterNode;
 import com.foundationdb.sql.parser.SQLParserException;
 import com.foundationdb.sql.parser.StatementNode;
-
 import com.foundationdb.qp.operator.QueryBindings;
 import com.foundationdb.qp.operator.QueryContext;
 import com.foundationdb.server.api.DDLFunctions;
@@ -39,22 +37,24 @@ import com.foundationdb.server.service.metrics.LongMetric;
 import com.foundationdb.server.service.monitor.CursorMonitor;
 import com.foundationdb.server.service.monitor.MonitorStage;
 import com.foundationdb.server.service.monitor.PreparedStatementMonitor;
-
+import com.foundationdb.server.service.monitor.SessionMonitor.StatementTypes;
 import com.foundationdb.util.MultipleCauseException;
 import com.foundationdb.util.tap.InOutTap;
 import com.foundationdb.util.tap.Tap;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.ietf.jgss.*;
+
 import java.security.Principal;
 import java.security.PrivilegedAction;
 import java.security.SecureRandom;
+
 import javax.security.auth.Subject;
 import javax.security.auth.login.LoginException;
 
 import java.net.*;
+
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
 
@@ -695,9 +695,11 @@ public class PostgresServerConnection extends ServerSessionBase
         updateAIS(context);
         
         PostgresStatement pstmt = null;
-        if (statementCache != null)
+        if (statementCache != null) 
             pstmt = statementCache.get(sql);
-        if (pstmt == null) {
+        if (pstmt != null) {
+            sessionMonitor.countEvent(StatementTypes.FROM_CACHE);
+        } else {
             for (PostgresStatementParser parser : unparsedGenerators) {
                 // Try special recognition first; only allowed to turn
                 // into one statement.
@@ -1284,6 +1286,7 @@ public class PostgresServerConnection extends ServerSessionBase
         PostgresBoundQueryContext bound = boundPortals.get(name);
         if (bound == null)
             throw new NoSuchCursorException(name);
+        sessionMonitor.countEvent(StatementTypes.FROM_CACHE);
         QueryBindings bindings = bound.getBindings();
         PostgresPreparedStatement pstmt = bound.getStatement();
         sessionMonitor.startStatement(pstmt.getSQL(), pstmt.getName());

--- a/fdb-sql-layer-pg/src/main/java/com/foundationdb/sql/pg/PostgresServerStatement.java
+++ b/fdb-sql-layer-pg/src/main/java/com/foundationdb/sql/pg/PostgresServerStatement.java
@@ -28,16 +28,17 @@ import javax.management.ObjectName;
 import com.foundationdb.sql.optimizer.plan.CostEstimate;
 import com.foundationdb.sql.parser.ParameterNode;
 import com.foundationdb.sql.parser.StatementNode;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.foundationdb.qp.operator.QueryBindings;
-
 import com.foundationdb.server.error.AkibanInternalException;
 import com.foundationdb.server.error.ConnectionTerminatedException;
 import com.foundationdb.server.error.InvalidOperationException;
 import com.foundationdb.server.error.SecurityException;
 import com.foundationdb.server.error.UnsupportedConfigurationException;
+import com.foundationdb.server.service.monitor.SessionMonitor.StatementTypes;
 import com.foundationdb.sql.parser.AlterServerNode;
 
 public class PostgresServerStatement implements PostgresStatement {
@@ -90,6 +91,7 @@ public class PostgresServerStatement implements PostgresStatement {
         
         context.checkQueryCancelation();
         PostgresServerSession server = context.getServer();
+        server.getSessionMonitor().countEvent(StatementTypes.SERVER);
         try {
             doOperation(server);
         } catch (Exception e) {

--- a/fdb-sql-layer-pg/src/main/java/com/foundationdb/sql/pg/PostgresServerStatement.java
+++ b/fdb-sql-layer-pg/src/main/java/com/foundationdb/sql/pg/PostgresServerStatement.java
@@ -18,7 +18,6 @@ package com.foundationdb.sql.pg;
 
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
@@ -91,7 +90,7 @@ public class PostgresServerStatement implements PostgresStatement {
         
         context.checkQueryCancelation();
         PostgresServerSession server = context.getServer();
-        server.getSessionMonitor().countEvent(StatementTypes.SERVER);
+        server.getSessionMonitor().countEvent(StatementTypes.OTHER_STMT);
         try {
             doOperation(server);
         } catch (Exception e) {

--- a/fdb-sql-layer-pg/src/main/java/com/foundationdb/sql/pg/PostgresSessionStatement.java
+++ b/fdb-sql-layer-pg/src/main/java/com/foundationdb/sql/pg/PostgresSessionStatement.java
@@ -162,7 +162,7 @@ public class PostgresSessionStatement implements PostgresStatement
     @Override
     public int execute(PostgresQueryContext context, QueryBindings bindings, int maxrows) throws IOException {
         PostgresServerSession server = context.getServer();
-        server.getSessionMonitor().countEvent(StatementTypes.SESSION);
+        server.getSessionMonitor().countEvent(StatementTypes.OTHER_STMT);
         doOperation(context, server);
         {        
             PostgresMessenger messenger = server.getMessenger();

--- a/fdb-sql-layer-pg/src/main/java/com/foundationdb/sql/pg/PostgresSessionStatement.java
+++ b/fdb-sql-layer-pg/src/main/java/com/foundationdb/sql/pg/PostgresSessionStatement.java
@@ -27,6 +27,7 @@ import com.foundationdb.server.error.NoSuchConstraintException;
 import com.foundationdb.server.error.NoSuchSchemaException;
 import com.foundationdb.server.error.UnsupportedConfigurationException;
 import com.foundationdb.server.error.UnsupportedSQLException;
+import com.foundationdb.server.service.monitor.SessionMonitor.StatementTypes;
 import com.foundationdb.sql.optimizer.plan.CostEstimate;
 import com.foundationdb.sql.parser.AccessMode;
 import com.foundationdb.sql.parser.IsolationLevel;
@@ -161,6 +162,7 @@ public class PostgresSessionStatement implements PostgresStatement
     @Override
     public int execute(PostgresQueryContext context, QueryBindings bindings, int maxrows) throws IOException {
         PostgresServerSession server = context.getServer();
+        server.getSessionMonitor().countEvent(StatementTypes.SESSION);
         doOperation(context, server);
         {        
             PostgresMessenger messenger = server.getMessenger();


### PR DESCRIPTION
This merge does two things. 

It add a collection of counter to the SessionMonitor for counting the types of statements being run through the Postgres Interface. The counters enhance the "Statements" count with Failed, From Cache, and Logged statments, plus a count of the different types of statements : Select, DML, DDL, call, copy, explain, emulated metadata, alter session, and alter server calls. These statistics are exposed through additional columns to the IS.SERVER_SESSIONS table.

Second it makes the MonitorService also collect the same set of statistics from all the sessions. These are exposed through a new IS.SERVER_STATISTICS_SUMMARY table. 