### PR TITLE
Make network server startup messages parallel.

### DIFF
--- a/fdb-sql-layer-rest/src/main/java/com/foundationdb/http/HttpConductorImpl.java
+++ b/fdb-sql-layer-rest/src/main/java/com/foundationdb/http/HttpConductorImpl.java
@@ -250,7 +250,7 @@ public final class HttpConductorImpl implements HttpConductor, Service {
         boolean sslOn = Boolean.parseBoolean(sslProperty);
 
         boolean crossOriginOn = Boolean.parseBoolean(configurationService.getProperty(CONFIG_XORIGIN_ENABLED));
-        logger.info("Starting {} service on {}:{} with authentication {} and CORS {}",
+        logger.info("Starting {} server listening on {}:{} with authentication {} and CORS {}",
                     new Object[] { sslOn ? "HTTPS" : "HTTP", hostLocal, portLocal, login, crossOriginOn ? "on" : "off"});
                     
         Server localServer = new Server();


### PR DESCRIPTION
Postgres was delaying figuring out what authentication to use from config properties until the first connect, which doesn't seem important.

Also clarify in a comment what a nearby authentication-related method is doing.