### PR TITLE
Fix constraint dropping

### DIFF
--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/ais/model/Constraint.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/ais/model/Constraint.java
@@ -18,5 +18,6 @@
 package com.foundationdb.ais.model;
 
 public interface Constraint {
+    public Table getConstraintTable();
     public TableName getConstraintName();
 }

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/ais/model/ForeignKey.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/ais/model/ForeignKey.java
@@ -101,6 +101,11 @@ public class ForeignKey implements Constraint
         return findIndex(referencingTable, referencingColumns, false);
     }
 
+    @Override
+    public Table getConstraintTable() {
+        return getReferencingTable();
+    }
+
     public TableName getConstraintName() {
         return constraintName;
     }

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/ais/model/Index.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/ais/model/Index.java
@@ -443,8 +443,13 @@ public abstract class Index extends HasStorage implements Visitable, Constraint
 
     // constraint
 
+    @Override
+    public Table getConstraintTable() {
+        return null;
+    }
+
+    @Override
     public TableName getConstraintName() {
         return constraintName;
     }
-
 }

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/ais/model/Join.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/ais/model/Join.java
@@ -152,6 +152,12 @@ public class Join implements HasGroup, Constraint
         joinName = newName;
     }
 
+    @Override
+    public Table getConstraintTable() {
+        return child;
+    }
+
+    @Override
     public TableName getConstraintName(){
         return constraintName;
     }

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/ais/model/TableIndex.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/ais/model/TableIndex.java
@@ -180,6 +180,15 @@ public class TableIndex extends Index
         return hKey;
     }
 
+    //
+    // Constraint
+    //
+
+    @Override
+    public Table getConstraintTable() {
+        return table;
+    }
+
     private final Table table;
     private HKey hKey;
     private IndexToHKey indexToHKey;

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/sql/aisddl/AlterTableDDL.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/sql/aisddl/AlterTableDDL.java
@@ -528,19 +528,17 @@ public class AlterTableDDL {
             break;
             case NodeTypes.MODIFY_COLUMN_TYPE_NODE: // All but [NOT] NULL comes from type
                 {
-                    TInstance type = typesTranslator
-                        .typeForSQLType(modNode.getType())
-                        .withNullable(column.getNullable());
-                    if (false) {
-                        // TODO: Determine whether compatible, does affect sequence, etc.
-                        column.setType(type);
-                    }
-                    else {
-                        tableCopy.dropColumn(modNode.getColumnName());
-                        builder.column(tableCopy.getName().getSchemaName(), tableCopy.getName().getTableName(), column.getName(),
-                                       column.getPosition(), type, false, // column.getInitialAutoIncrementValue() != null
-                                       column.getDefaultValue(), column.getDefaultFunction());
-                    }
+                    TInstance type = typesTranslator.typeForSQLType(modNode.getType())
+                                                    .withNullable(column.getNullable());
+                    tableCopy.dropColumn(modNode.getColumnName());
+                    builder.column(tableCopy.getName().getSchemaName(),
+                                   tableCopy.getName().getTableName(),
+                                   column.getName(),
+                                   column.getPosition(),
+                                   type,
+                                   false,
+                                   column.getDefaultValue(),
+                                   column.getDefaultFunction());
                 }
             break;
             default:

--- a/fdb-sql-layer-core/src/test/java/com/foundationdb/sql/aisddl/AlterTableDDLTest.java
+++ b/fdb-sql-layer-core/src/test/java/com/foundationdb/sql/aisddl/AlterTableDDLTest.java
@@ -576,19 +576,19 @@ public class AlterTableDDLTest {
 
     @Test
       public void dropUniqueSingleColumnSingleTableGroup() throws StandardException {
-        builder.table(C_NAME).colBigInt("c1", false).uniqueKey("c1", "c1");
+        builder.table(C_NAME).colBigInt("c1", false).uniqueConstraint("c1", "c1_idx", "c1");
         parseAndRun("ALTER TABLE c DROP UNIQUE c1");
         expectColumnChanges();
-        expectIndexChanges("DROP:c1");
+        expectIndexChanges("DROP:c1_idx");
         expectFinalTable(C_NAME, "c1 MCOMPAT_ BIGINT(21) NOT NULL");
     }
 
     @Test
     public void dropUniqueMultiColumnSingleTableGroup() throws StandardException {
-        builder.table(C_NAME).colBigInt("c1", false).colBigInt("c2", false).uniqueKey("x", "c2", "c1");
+        builder.table(C_NAME).colBigInt("c1", false).colBigInt("c2", false).uniqueConstraint("x", "x_idx", "c2", "c1");
         parseAndRun("ALTER TABLE c DROP UNIQUE x");
         expectColumnChanges();
-        expectIndexChanges("DROP:x");
+        expectIndexChanges("DROP:x_idx");
         expectFinalTable(C_NAME, "c1 MCOMPAT_ BIGINT(21) NOT NULL", "c2 MCOMPAT_ BIGINT(21) NOT NULL");
     }
 
@@ -596,11 +596,11 @@ public class AlterTableDDLTest {
     public void dropUniqueMiddleOfGroup() throws StandardException {
         buildCOIJoinedAUnJoined();
         AISBuilder builder2 = new AISBuilder(builder.unvalidatedAIS());
-        builder2.unique(SCHEMA, "o", "x");
-        builder2.indexColumn(SCHEMA, "o", "x", "o_o", 0, true, null);
+        builder2.uniqueConstraint(SCHEMA, "o", "x_idx", new TableName(SCHEMA, "x"));
+        builder2.indexColumn(SCHEMA, "o", "x_idx", "o_o", 0, true, null);
         parseAndRun("ALTER TABLE o DROP UNIQUE x");
         expectColumnChanges();
-        expectIndexChanges("DROP:x");
+        expectIndexChanges("DROP:x_idx");
         expectFinalTable(O_NAME, "id MCOMPAT_ BIGINT(21) NOT NULL", "cid MCOMPAT_ BIGINT(21) NULL", "o_o MCOMPAT_ BIGINT(21) NULL",
                          "fk1(cid)", "PRIMARY(id)", "join(cid->id)");
         expectUnchangedTables(C_NAME, I_NAME, A_NAME);
@@ -771,6 +771,13 @@ public class AlterTableDDLTest {
     public void cannotDropConstraintRegularIndex() throws StandardException {
         builder.table(C_NAME).colBigInt("c1", false).key("c1", "c1");
         parseAndRun("ALTER TABLE c DROP CONSTRAINT c1");
+    }
+
+    @Test(expected=NoSuchConstraintException.class)
+    public void cannotDropConstraintOnDifferentTable() throws StandardException {
+        builder.table(C_NAME).colBigInt("c1", false).uniqueConstraint("c1", "c1_idx", "c1");
+        builder.table(A_NAME).colBigInt("a1", false).uniqueConstraint("a1", "a1_idx", "a1");
+        parseAndRun("ALTER TABLE a DROP CONSTRAINT c1");
     }
 
     @Test

--- a/fdb-sql-layer-test-yaml/src/test/resources/com/foundationdb/sql/test/yaml/functional/test-alter-drop-constraint-long-identifier.yaml
+++ b/fdb-sql-layer-test-yaml/src/test/resources/com/foundationdb/sql/test/yaml/functional/test-alter-drop-constraint-long-identifier.yaml
@@ -1,0 +1,13 @@
+# Originally caught by Django test suite
+# Dropping a constraint by name was picking up the backing instead
+---
+- CreateTable: test_rmwsrf_pony (id INT NOT NULL PRIMARY KEY)
+---
+- CreateTable: test_rmwsrf_rider (id INT NOT NULL PRIMARY KEY, pony_id integer NOT NULL, friend_id integer NOT NULL)
+---
+- Statement: ALTER TABLE test_rmwsrf_rider
+             ADD CONSTRAINT test_rmwsrf_rider_friend_id_65b09aa1a82028b6_fk_test_rmwsrf_rider_id
+             FOREIGN KEY (friend_id) REFERENCES test_rmwsrf_rider (id)
+---
+- Statement: ALTER TABLE test_rmwsrf_rider
+             DROP CONSTRAINT test_rmwsrf_rider_friend_id_65b09aa1a82028b6_fk_test_rmwsrf_rider_id


### PR DESCRIPTION
The alter code was still looking index names to figure out which constraint to drop. That isn't correct now that we have real constraint names and could fail when ones that often match didn't.