### PR TITLE
Update Jetty dependency to latest in 8.1 stream

### DIFF
--- a/fdb-sql-layer-rest/pom.xml
+++ b/fdb-sql-layer-rest/pom.xml
@@ -66,18 +66,24 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
-            <version>8.1.3.v20120416</version>
+            <version>8.1.16.v20140903</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlet</artifactId>
-            <version>8.1.3.v20120416</version>
+            <version>8.1.16.v20140903</version>
         </dependency>
         <!-- For CrossOriginFilter -->
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlets</artifactId>
-            <version>8.1.3.v20120416</version>
+            <version>8.1.16.v20140903</version>
+        </dependency>
+        <!-- For customer configurations -->
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-plus</artifactId>
+            <version>8.1.16.v20140903</version>
         </dependency>
         <!-- REST -->
         <dependency>


### PR DESCRIPTION
There is a task to upgrade to 9, but that requires some changes on our end.

Also add jetty-plus, which has modules that customer may want to configure with some upcoming changes.

The purpose of having this as a separate PR is just to see whether anything breaks.