### PR TITLE
Re-enable the metrics service 

### DIFF
--- a/fdb-sql-layer-core/src/main/resources/com/foundationdb/server/service/servicemanager/default-services.yaml
+++ b/fdb-sql-layer-core/src/main/resources/com/foundationdb/server/service/servicemanager/default-services.yaml
@@ -40,7 +40,7 @@
     com.foundationdb.server.store.Store : com.foundationdb.server.store.FDBStore
     com.foundationdb.server.store.statistics.IndexStatisticsService : com.foundationdb.server.store.statistics.FDBIndexStatisticsService
     com.foundationdb.server.service.transaction.TransactionService : com.foundationdb.server.store.FDBTransactionService
-    #com.foundationdb.server.service.metrics.MetricsService : com.foundationdb.server.service.metrics.FDBMetricsService
-    com.foundationdb.server.service.metrics.MetricsService : com.foundationdb.server.service.metrics.DummyMetricsService
+    com.foundationdb.server.service.metrics.MetricsService : com.foundationdb.server.service.metrics.FDBMetricsService
+    #com.foundationdb.server.service.metrics.MetricsService : com.foundationdb.server.service.metrics.DummyMetricsService
     com.foundationdb.sql.optimizer.rule.cost.CostModelFactory : com.foundationdb.sql.optimizer.rule.cost.PersistitCostModelService
     com.foundationdb.server.service.text.FullTextIndexService: com.foundationdb.server.service.text.ThrowingFullTextService


### PR DESCRIPTION
This allows the SQL Layer to push metrics into the FDB KVStore metrics management system.