### PR TITLE
Support LDAP authentication

### DIFF
--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/service/security/SecurityService.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/service/security/SecurityService.java
@@ -24,17 +24,54 @@ import java.util.Collection;
 
 public interface SecurityService
 {
+    /** This role allows access to all data. */
     public static final String ADMIN_ROLE = "admin";
 
-    public static final Session.Key<User> SESSION_KEY = 
-        Session.Key.named("SECURITY_USER");
+    /** The current {@link Principal} for the {@link Session}. */
+    public static final Session.Key<Principal> SESSION_PRINCIPAL_KEY = 
+        Session.Key.named("SECURITY_PRINCIPAL");
 
-    public User authenticate(Session session, String name, String password);
-    public User authenticate(Session session, String name, String password, byte[] salt);
+    /** The current roles for the {@link Session}. */
+    public static final Session.Key<Collection<String>> SESSION_ROLES_KEY = 
+        Session.Key.named("SECURITY_ROLES");
 
+    /** Authenticate user using local security database and set into {@link Session}.
+     * @return the logged in {@link Principal}.
+     * Throws an error if authentication fails.
+     */
+    public Principal authenticateLocal(Session session, String name, String password);
+
+    /** Authenticate user using local security database and set in {@link Session}.
+     * @param salt a salt to use when hashing the password
+     */
+    public Principal authenticateLocal(Session session, String name, String password,
+                                       byte[] salt);
+
+    /** If this {@link Session} is authenticated, does it have access to the given schema?
+     *
+     * NOTE: If authentication is enabled, caller must not call this (that is, allow
+     * any queries) without authentication, since that is indistinguishable from
+     * authentication disabled.
+     *
+     * @see com.foundationdb.sql.pg.PostgresServerConnection#authenticationOkay
+     */
     public boolean isAccessible(Session session, String schema);
+    
+    /** Does the given {@link Principal} have access to the given scheam?
+     * NOTE: If authentication is enabled, caller must not call this (that is, allow
+     * any queries) with <code>null</code>, since that is indistinguishable from
+     * authentication disabled.
+     *
+     * @see com.foundationdb.http.HttpConductorImpl.AuthenticationType
+     */
     public boolean isAccessible(Principal user, boolean inAdminRole, String schema);
+
+    /** If this {@link Session} is authenticated, does it administrative access?
+     */
     public boolean hasRestrictedAccess(Session session);
+
+    /** Set {@link Session}'s authentication directly. */
+    public void setAuthenticated(Session session, Principal user, boolean inAdminRole);
 
     public void addRole(String name);
     public void deleteRole(String name);

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/service/security/SecurityService.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/service/security/SecurityService.java
@@ -73,6 +73,13 @@ public interface SecurityService
     /** Set {@link Session}'s authentication directly. */
     public void setAuthenticated(Session session, Principal user, boolean inAdminRole);
 
+    /** Authenticate user using given JAAS configuration and set in {@link Session}.
+     * @param configName name of the JAAS configuration to use
+     * @param roleClasses list of {@link Principal} classes that represent roles or <code>null</code> to get from corresponding user in local database.
+     */
+    public Principal authenticateJaas(Session session, String name, String password,
+                                      String configName, Class<? extends Principal> userClass, Collection<Class<? extends Principal>> roleClasses);
+
     public void addRole(String name);
     public void deleteRole(String name);
     public User getUser(String name);

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/sql/embedded/EmbeddedJDBCService.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/sql/embedded/EmbeddedJDBCService.java
@@ -26,5 +26,5 @@ import java.util.Properties;
 public interface EmbeddedJDBCService
 {
     public Driver getDriver();
-    public Connection newConnection(Properties properties, Principal principal) throws SQLException;
+    public Connection newConnection(Properties properties, Principal principal, boolean isAdminRole) throws SQLException;
 }

--- a/fdb-sql-layer-core/src/test/java/com/foundationdb/server/service/security/DummySecurityService.java
+++ b/fdb-sql-layer-core/src/test/java/com/foundationdb/server/service/security/DummySecurityService.java
@@ -19,14 +19,17 @@ package com.foundationdb.server.service.security;
 
 import com.foundationdb.server.service.session.Session;
 
+import java.security.Principal;
+import java.util.Collection;
+
 public class DummySecurityService implements SecurityService {
     @Override
-    public User authenticate(Session session, String name, String password) {
+    public Principal authenticateLocal(Session session, String name, String password) {
         return null;
     }
 
     @Override
-    public User authenticate(Session session, String name, String password, byte[] salt) {
+    public Principal authenticateLocal(Session session, String name, String password, byte[] salt) {
         return null;
     }
 
@@ -43,6 +46,10 @@ public class DummySecurityService implements SecurityService {
     @Override
     public boolean hasRestrictedAccess(Session session) {
         return true;
+    }
+
+    @Override
+    public void setAuthenticated(Session session, Principal user, boolean inAdminRole) {
     }
 
     @Override

--- a/fdb-sql-layer-core/src/test/java/com/foundationdb/server/service/security/DummySecurityService.java
+++ b/fdb-sql-layer-core/src/test/java/com/foundationdb/server/service/security/DummySecurityService.java
@@ -34,6 +34,12 @@ public class DummySecurityService implements SecurityService {
     }
 
     @Override
+    public Principal authenticateJaas(Session session, String name, String password,
+                                      String configName, Class<? extends Principal> userClass, Collection<Class<? extends Principal>> roleClasses) {
+        return null;
+    }
+
+    @Override
     public boolean isAccessible(Session session, String schema) {
         return true;
     }

--- a/fdb-sql-layer-core/src/test/java/com/foundationdb/server/service/security/SecurityServiceITBase.java
+++ b/fdb-sql-layer-core/src/test/java/com/foundationdb/server/service/security/SecurityServiceITBase.java
@@ -89,7 +89,7 @@ public abstract class SecurityServiceITBase extends ITBase
 
     @Test
     public void authenticate() {
-        assertEquals("user1", securityService().authenticate(session(), "user1", "password").getName());
+        assertEquals("user1", securityService().authenticateLocal(session(), "user1", "password").getName());
     }
 
 }

--- a/fdb-sql-layer-pg/src/main/java/com/foundationdb/sql/pg/PostgresServer.java
+++ b/fdb-sql-layer-pg/src/main/java/com/foundationdb/sql/pg/PostgresServer.java
@@ -45,6 +45,7 @@ import java.util.Properties;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.security.Principal;
 import javax.security.auth.Subject;
 import javax.security.auth.login.LoginContext;
 import javax.security.auth.login.LoginException;
@@ -63,7 +64,7 @@ public class PostgresServer implements Runnable, PostgresMXBean, ServerMonitor {
     private static final String BYTES_OUT_METRIC_NAME = "PostgresBytesOut";
 
     protected static enum AuthenticationType {
-        NONE, CLEAR_TEXT, MD5, GSS
+        NONE, CLEAR_TEXT, MD5, GSS, JAAS
     };
 
     private final Properties properties;
@@ -87,6 +88,9 @@ public class PostgresServer implements Runnable, PostgresMXBean, ServerMonitor {
     private final CacheCounters cacheCounters = new CacheCounters();
     private AuthenticationType authenticationType;
     private Subject gssLogin;
+    private String jaasConfigName;
+    private Class<? extends Principal> jaasUserClass;
+    private Collection<Class<? extends Principal>> jaasRoleClasses;
     private final int slowLimit;
     private final int hardLimit;
 
@@ -399,6 +403,31 @@ public class PostgresServer implements Runnable, PostgresMXBean, ServerMonitor {
         if (properties.getProperty("gssConfigName") != null) {
             authenticationType = AuthenticationType.GSS;
         }
+        else if (properties.getProperty("jaas.configName") != null) {
+            authenticationType = AuthenticationType.JAAS;
+            jaasConfigName = properties.getProperty("jaas.configName");
+            String cprop = properties.getProperty("jaas.userClass");
+            if (cprop != null) {
+                try {
+                    jaasUserClass = Class.forName(cprop).asSubclass(Principal.class);
+                }
+                catch (ClassNotFoundException ex) {
+                    throw new IllegalArgumentException("Invalid jaas.userClass", ex);
+                }
+            }
+            cprop = properties.getProperty("jaas.roleClasses");
+            if (cprop != null) {
+                jaasRoleClasses = new ArrayList<>();
+                try {
+                    for (String c : cprop.split(",")) {
+                        jaasRoleClasses.add(Class.forName(c.trim()).asSubclass(Principal.class));
+                    }
+                }
+                catch (ClassNotFoundException ex) {
+                    throw new IllegalArgumentException("Invalid jaas.roleClasses", ex);
+                }
+            }
+        }
         else {
             String login = properties.getProperty("login", "none");
             if (login.equals("none")) {
@@ -428,6 +457,18 @@ public class PostgresServer implements Runnable, PostgresMXBean, ServerMonitor {
             gssLogin = lc.getSubject();
         }
         return gssLogin;
+    }
+
+    public String getJaasConfigName() {
+        return jaasConfigName;
+    }
+
+    public Class<? extends Principal> getJaasUserClass() {
+        return jaasUserClass;
+    }
+
+    public Collection<Class<? extends Principal>> getJaasRoleClasses() {
+        return jaasRoleClasses;
     }
 
     /* ServerMonitor */

--- a/fdb-sql-layer-pg/src/main/java/com/foundationdb/sql/pg/PostgresServerConnection.java
+++ b/fdb-sql-layer-pg/src/main/java/com/foundationdb/sql/pg/PostgresServerConnection.java
@@ -576,11 +576,12 @@ public class PostgresServerConnection extends ServerSessionBase
             break;
         case CLEAR_TEXT:
             principal = reqs.securityService()
-                .authenticate(session, user, pass);
+                .authenticateLocal(session, user, pass);
             break;
         case MD5:
             principal = reqs.securityService()
-                .authenticate(session, user, pass, (byte[])attributes.remove(MD5_SALT));
+                .authenticateLocal(session, user, pass,
+                                   (byte[])attributes.remove(MD5_SALT));
             break;
         }
         logger.debug("Login {}", (principal != null) ? principal : user);

--- a/fdb-sql-layer-pg/src/main/java/com/foundationdb/sql/pg/PostgresServerConnection.java
+++ b/fdb-sql-layer-pg/src/main/java/com/foundationdb/sql/pg/PostgresServerConnection.java
@@ -510,6 +510,7 @@ public class PostgresServerConnection extends ServerSessionBase
             }
             break;
         case CLEAR_TEXT:
+        case JAAS:
             {
                 messenger.beginMessage(PostgresMessages.AUTHENTICATION_TYPE.code());
                 messenger.writeInt(PostgresMessenger.AUTHENTICATION_CLEAR_TEXT);
@@ -582,6 +583,11 @@ public class PostgresServerConnection extends ServerSessionBase
             principal = reqs.securityService()
                 .authenticateLocal(session, user, pass,
                                    (byte[])attributes.remove(MD5_SALT));
+            break;
+        case JAAS:
+            principal = reqs.securityService()
+                .authenticateJaas(session, user, pass,
+                                  server.getJaasConfigName(), server.getJaasUserClass(), server.getJaasRoleClasses());
             break;
         }
         logger.debug("Login {}", (principal != null) ? principal : user);

--- a/fdb-sql-layer-rest/src/main/java/com/foundationdb/http/HttpConductorImpl.java
+++ b/fdb-sql-layer-rest/src/main/java/com/foundationdb/http/HttpConductorImpl.java
@@ -281,7 +281,7 @@ public final class HttpConductorImpl implements HttpConductor, Service {
         localServer.addBean(new JsonErrorHandler());
 
         try {
-            if(login != AuthenticationType.NONE) {
+            if (login != AuthenticationType.NONE) {
                 Authenticator authenticator = login.createAuthenticator();
                 Constraint constraint = new Constraint(authenticator.getAuthMethod(), REST_ROLE);
                 constraint.setAuthenticate(true);
@@ -290,14 +290,16 @@ public final class HttpConductorImpl implements HttpConductor, Service {
                 cm.setPathSpec("/*");
                 cm.setConstraint(constraint);
 
+                String realm = configurationService.getProperty(CONFIG_REALM);
+
                 ConstraintSecurityHandler sh =
                         crossOriginOn ? new CrossOriginConstraintSecurityHandler() : new ConstraintSecurityHandler();
                 sh.setAuthenticator(authenticator);
                 sh.setConstraintMappings(Collections.singletonList(cm));
+                sh.setRealmName(realm);
 
                 LoginService loginService =
-                        new SecurityServiceLoginService(securityService, login.getCredentialType(), loginCacheSeconds,
-                                configurationService.getProperty(CONFIG_REALM));
+                        new SecurityServiceLoginService(securityService, login.getCredentialType(), loginCacheSeconds, realm);
                 sh.setLoginService(loginService);
 
                 localRootContextHandler.setSecurityHandler(sh);

--- a/fdb-sql-layer-rest/src/main/java/com/foundationdb/http/HttpConductorImpl.java
+++ b/fdb-sql-layer-rest/src/main/java/com/foundationdb/http/HttpConductorImpl.java
@@ -312,8 +312,11 @@ public final class HttpConductorImpl implements HttpConductor, Service {
                     jaasLoginService.setLoginModuleName(jaasProps.getProperty("configName"));
                     if (jaasProps.getProperty("roleClasses") != null) {
                         jaasLoginService.setRoleClassNames(jaasProps.getProperty("roleClasses").split(",\\s+"));
+                        loginService = jaasLoginService;
                     }
-                    loginService = jaasLoginService;
+                    else {
+                        loginService = new HybridLoginService(jaasLoginService, securityService);
+                    }
                 }
                 else {
                     loginService = new SecurityServiceLoginService(securityService, login.getCredentialType(), loginCacheSeconds, realm);

--- a/fdb-sql-layer-rest/src/main/java/com/foundationdb/http/HybridLoginService.java
+++ b/fdb-sql-layer-rest/src/main/java/com/foundationdb/http/HybridLoginService.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (C) 2009-2015 FoundationDB, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.foundationdb.http;
+
+import com.foundationdb.server.service.security.SecurityService;
+import com.foundationdb.server.service.security.User;
+import org.eclipse.jetty.security.IdentityService;
+import org.eclipse.jetty.security.LoginService;
+import org.eclipse.jetty.server.UserIdentity;
+import java.security.Principal;
+import javax.security.auth.Subject;
+
+public class HybridLoginService implements LoginService
+{
+    private final LoginService delegate;
+    private final SecurityService securityService;
+
+    public HybridLoginService(LoginService delegate, SecurityService securityService) {
+        this.delegate = delegate;
+        this.securityService = securityService;
+    }
+
+    @Override
+    public String getName() {
+        return delegate.getName();
+    }
+
+    @Override
+    public UserIdentity login(String username, Object credentials) {
+        UserIdentity inner = delegate.login(username, credentials);
+        if (inner == null)
+            return null;
+        User user = securityService.getUser(inner.getUserPrincipal().getName());
+        if (user == null)
+            return inner;
+        else
+            return new WrappedUserIdentity(inner, user);
+    }
+
+    @Override
+    public boolean validate(UserIdentity user) {
+        return delegate.validate(unwrap(user));
+    }
+
+    @Override
+    public IdentityService getIdentityService() {
+        return delegate.getIdentityService();
+    }
+
+    @Override
+    public void setIdentityService(IdentityService service) {
+        delegate.setIdentityService(service);
+    }
+
+    @Override
+    public void logout(UserIdentity user) {
+        delegate.logout(unwrap(user));
+    }
+
+    protected static class WrappedUserIdentity implements UserIdentity {
+        private final UserIdentity delegate;
+        private final User user;
+
+        public WrappedUserIdentity(UserIdentity delegate, User user) {
+            this.delegate = delegate;
+            this.user = user;
+        }
+
+        @Override
+        public Subject getSubject() {
+            return delegate.getSubject();
+        }
+
+        @Override
+        public Principal getUserPrincipal() {
+            return delegate.getUserPrincipal();
+        }
+
+        @Override
+        public boolean isUserInRole(String role, UserIdentity.Scope scope) {
+            return delegate.isUserInRole(role, scope) || user.hasRole(role);
+        }
+    }
+
+    protected UserIdentity unwrap(UserIdentity user) {
+        if (user instanceof WrappedUserIdentity)
+            return ((WrappedUserIdentity)user).delegate;
+        else
+            return user;
+    }
+}

--- a/fdb-sql-layer-rest/src/main/java/com/foundationdb/rest/dml/RestDMLServiceImpl.java
+++ b/fdb-sql-layer-rest/src/main/java/com/foundationdb/rest/dml/RestDMLServiceImpl.java
@@ -33,6 +33,7 @@ import com.foundationdb.server.service.config.ConfigurationService;
 import com.foundationdb.server.service.dxl.DXLService;
 import com.foundationdb.server.service.externaldata.ExternalDataService;
 import com.foundationdb.server.service.externaldata.JsonRowWriter;
+import com.foundationdb.server.service.security.SecurityService;
 import com.foundationdb.server.service.session.Session;
 import com.foundationdb.server.service.session.SessionService;
 import com.foundationdb.server.service.text.FullTextIndexService;
@@ -552,7 +553,7 @@ public class RestDMLServiceImpl implements Service, RestDMLService {
     }
 
     private JDBCConnection jdbcConnection(HttpServletRequest request) throws SQLException {
-        return (JDBCConnection) jdbcService.newConnection(new Properties(), request.getUserPrincipal());
+        return (JDBCConnection) jdbcService.newConnection(new Properties(), request.getUserPrincipal(), request.isUserInRole(SecurityService.ADMIN_ROLE));
     }
 
     private JDBCConnection jdbcConnection(HttpServletRequest request, String schemaName) throws SQLException {
@@ -563,7 +564,7 @@ public class RestDMLServiceImpl implements Service, RestDMLService {
             (schemaName != null)) {
             properties.put("user", schemaName);
         }
-        return (JDBCConnection) jdbcService.newConnection(properties, request.getUserPrincipal());
+        return (JDBCConnection) jdbcService.newConnection(properties, request.getUserPrincipal(), request.isUserInRole(SecurityService.ADMIN_ROLE));
     }
 
     private static enum OutputType {


### PR DESCRIPTION
@nathanlws convinced me that doing this via JAAS was the best, if not the simplest, way.

As with Kerberos, the JAAS configuration file must be configured in `jvm.options`. A `fdbsql.{sql,postgres,http}.jaas.configName` config setting names the login module to use. Unlike with GSS, this module logs the client in, not the server. See https://bitbucket.org/mmcm/sql-layer-docker/src/470ddfb7a583d3a57a893cd05592fa2ab4a663b5/ldap-sql-layer/jaas.conf?at=master for examples.

If `...jaas.roleClasses` is defined, it names `Principal` classes that are taken from the `Subject` and assumed to have names that map directly to roles in the SQL layer. In short, roles come from directory. If this is not defined, roles come from the security database, matching the name of the user `Principal` after authentication.

The security service `Session` setting is no longer a `User`. Right now, there are separate keys for the user `Principal` and a list of role names. I suspect something consolidated like Jetty's `UserIdentity` will emerge from the per-table security support, so I kept it simplest for now.

Postgres does authentication by calling the security service and so only maintains all the config settings for this. REST must set up a Jetty `LoginService` and so much decode the settings, which are mostly parallel, into what that requires.

There is no testing in this branch, since an LDAP server is required. As we know, it is time to get Docker running more automatically.