### PR TITLE
Opening embedded JDBC driver is allowed to overwrite the inherited schema

### DIFF
--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/sql/embedded/JDBCConnection.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/sql/embedded/JDBCConnection.java
@@ -72,9 +72,15 @@ public class JDBCConnection extends ServerSessionBase implements Connection {
         super(reqs);
         sessionMonitor = new ServerSessionMonitor(SERVER_TYPE, reqs.monitor().allocateSessionId());
         inheritFromCall();
-        if ((defaultSchemaName != null) &&
-            (info.getProperty("database") == null))
-            info.put("database", defaultSchemaName);
+        if (info.getProperty("database") == null) {
+            if (defaultSchemaName != null)
+                // From caller into properties.
+                info.put("database", defaultSchemaName);
+        }
+        else {
+            // From properties, overwriting caller.
+            defaultSchemaName = info.getProperty("database");
+        }
         if (session == null)
             session = reqs.sessionService().createSession();
         setProperties(info);

--- a/fdb-sql-layer-test-yaml/src/test/resources/com/foundationdb/sql/test/yaml/bugs/test-embedded-jdbc-schema.yaml
+++ b/fdb-sql-layer-test-yaml/src/test/resources/com/foundationdb/sql/test/yaml/bugs/test-embedded-jdbc-schema.yaml
@@ -1,0 +1,22 @@
+---
+- Statement: >
+    CREATE PROCEDURE embedded_schema(OUT schema1 VARCHAR(128), OUT schema2 VARCHAR(128), OUT schema3 VARCHAR(128)) AS $$
+      function fun(schema1, schema2, schema3) { 
+        var conn = java.sql.DriverManager.getConnection('jdbc:default:connection');
+        schema1[0] = conn.getSchema();
+        conn.close();
+        conn = java.sql.DriverManager.getConnection('jdbc:default:connection', 'test3', '');
+        schema2[0] = conn.getSchema();
+        conn.close();
+        var props = new java.util.Properties();
+        props.setProperty('user', 'test4');
+        props.setProperty('database', 'test5');
+        conn = java.sql.DriverManager.getConnection('jdbc:default:connection', props);
+        schema3[0] = conn.getSchema();
+        conn.close();
+      }
+    $$ LANGUAGE javascript PARAMETER STYLE java EXTERNAL NAME 'fun';
+---
+- Statement: CALL embedded_schema()
+- output: [['test', 'test', 'test5']]
+...


### PR DESCRIPTION
Using the "database" property. If none is supplied, it moves in the other direction, as before (as of relatively recently).