### PR TITLE
Log errors in query log if they meet the time constraint or are timeout-related

### DIFF
--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/service/monitor/MonitorService.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/service/monitor/MonitorService.java
@@ -52,10 +52,11 @@ public interface MonitorService {
     Collection<SessionMonitor> getSessionMonitors();
 
     /** Log the given SQL to the query log. */
-    void logQuery(int sessionId, String sqlText, long duration, int rowsProcessed);
+    void logQuery(int sessionId, String sqlText,
+                  long duration, int rowsProcessed, Throwable failure);
 
     /** Log last statement from given monitor. */
-    void logQuery(SessionMonitor sessionMonitor);
+    void logQuery(SessionMonitor sessionMonitor, Throwable failure);
     
     /** Register the given User monitor. */
     void registerUserMonitor (UserMonitor userMonitor);

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/service/monitor/SessionMonitorBase.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/service/monitor/SessionMonitorBase.java
@@ -69,6 +69,10 @@ public abstract class SessionMonitorBase implements SessionMonitor {
         rowsProcessed = -1;
     }
 
+    public void endStatement() {
+        endStatement(-1);
+    }
+
     public void endStatement(int rowsProcessed) {
         currentStatementEndTime = System.currentTimeMillis();
         this.rowsProcessed = rowsProcessed;
@@ -84,9 +88,9 @@ public abstract class SessionMonitorBase implements SessionMonitor {
         }
     }
     
-    public void failStatement() {
+    public void failStatement(Throwable failure) {
         countEvent(StatementTypes.FAILED);
-        endStatement(-1);
+        endStatement();
     }
 
     // Caller can sequence all stages and avoid any gaps at the cost of more complicated

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/sql/embedded/JDBCConnection.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/sql/embedded/JDBCConnection.java
@@ -268,7 +268,8 @@ public class JDBCConnection extends ServerSessionBase implements Connection {
 
     // Slightly different contract than ServerSessionBase, since a transaction
     // remains open when a until its read result set is closed.
-    protected void beforeExecuteStatement(ExecutableStatement stmt) throws SQLException {
+    protected void beforeExecuteStatement(String sql, ExecutableStatement stmt) throws SQLException {
+        sessionMonitor.startStatement(sql);
         sessionMonitor.enterStage(MonitorStage.EXECUTE);
         boolean localTransaction;
         try {
@@ -287,8 +288,15 @@ public class JDBCConnection extends ServerSessionBase implements Connection {
         }
     }
 
-    protected void afterExecuteStatement(ExecutableStatement stmt, boolean success) throws SQLException {
+    protected void afterExecuteStatement(ExecutableStatement stmt, Throwable failure) throws SQLException {
         sessionMonitor.leaveStage();
+        if (failure == null)
+            sessionMonitor.endStatement();
+        else
+            sessionMonitor.failStatement(failure);
+        if (reqs.monitor().isQueryLogEnabled()) {
+            reqs.monitor().logQuery(sessionMonitor, failure);
+        }
         boolean localTransaction = false;
         if (checkAutoCommit()) {
             // An update statement without any open cursors, or a
@@ -297,10 +305,10 @@ public class JDBCConnection extends ServerSessionBase implements Connection {
             // now.
             localTransaction = true;
             deregisterSessionMonitor();
-            logger.debug(success ? "Auto COMMIT TRANSACTION" : "Auto ROLLBACK TRANSACTION");
+            logger.debug((failure == null) ? "Auto COMMIT TRANSACTION" : "Auto ROLLBACK TRANSACTION");
         }
         try {
-            super.afterExecute(stmt, localTransaction, success, true);
+            super.afterExecute(stmt, localTransaction, (failure == null), true);
         }
         catch (RuntimeException ex) {
             throw JDBCException.throwUnwrapped(ex);


### PR DESCRIPTION
Previously only the timeout-related ones (e.g. `not_committed`) were logged.

Include error message in such an entry. Otherwise row count processed.

Also log from embedded driver more consistently.