### PR TITLE
Support for GEO_LAT_LON instead of Z_ORDER_LAT_LON

### DIFF
--- a/fdb-sql-layer-core/pom.xml
+++ b/fdb-sql-layer-core/pom.xml
@@ -85,7 +85,7 @@
         <dependency>
             <groupId>com.foundationdb</groupId>
             <artifactId>fdb-sql-parser</artifactId>
-            <version>1.6.0-SNAPSHOT</version>
+            <version>1.6.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -106,7 +106,7 @@
         <dependency>
             <groupId>com.foundationdb</groupId>
             <artifactId>fdb-sql-parser</artifactId>
-            <version>1.6.0-SNAPSHOT</version>
+            <version>1.6.1-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/ais/model/AISMerge.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/ais/model/AISMerge.java
@@ -381,9 +381,10 @@ public class AISMerge {
                 throw new IllegalArgumentException("Unknown index type: " + index);
         }
 
-        if(index.getIndexMethod() == Index.IndexMethod.Z_ORDER_LAT_LON) {
+        if(index.isSpatial()) {
             newIndex.markSpatial(index.firstSpatialArgument(),
-                                 index.lastSpatialArgument() - index.firstSpatialArgument() + 1);
+                                 index.lastSpatialArgument() - index.firstSpatialArgument() + 1,
+                                 index.functionName());
         }
 
         if(curIndex != null) {

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/ais/model/AISMerge.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/ais/model/AISMerge.java
@@ -384,7 +384,7 @@ public class AISMerge {
         if(index.isSpatial()) {
             newIndex.markSpatial(index.firstSpatialArgument(),
                                  index.lastSpatialArgument() - index.firstSpatialArgument() + 1,
-                                 index.functionName());
+                                 index.getIndexMethod());
         }
 
         if(curIndex != null) {

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/ais/model/GroupIndex.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/ais/model/GroupIndex.java
@@ -154,7 +154,7 @@ public class GroupIndex extends Index
         GroupIndex copy = create(ais, group, index.getIndexName().getName(), index.getIndexId(),
                                  index.isUnique(), index.isPrimaryKey(), index.getJoinType());
         if (index.isSpatial()) {
-            copy.markSpatial(index.firstSpatialArgument(), index.spatialColumns(), index.functionName());
+            copy.markSpatial(index.firstSpatialArgument(), index.spatialColumns(), index.getIndexMethod());
         }
         return copy;
     }

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/ais/model/GroupIndex.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/ais/model/GroupIndex.java
@@ -153,8 +153,8 @@ public class GroupIndex extends Index
     {
         GroupIndex copy = create(ais, group, index.getIndexName().getName(), index.getIndexId(),
                                  index.isUnique(), index.isPrimaryKey(), index.getJoinType());
-        if (index.getIndexMethod() == IndexMethod.Z_ORDER_LAT_LON) {
-            copy.markSpatial(index.firstSpatialArgument(), index.spatialColumns());
+        if (index.isSpatial()) {
+            copy.markSpatial(index.firstSpatialArgument(), index.spatialColumns(), index.functionName());
         }
         return copy;
     }

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/ais/model/Index.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/ais/model/Index.java
@@ -147,12 +147,7 @@ public abstract class Index extends HasStorage implements Visitable, Constraint
         return indexMethod;
     }
 
-    public String functionName()
-    {
-        return functionName;
-    }
-
-    public void markSpatial(int firstSpatialArgument, int spatialColumns, String functionName)
+    public void markSpatial(int firstSpatialArgument, int spatialColumns, IndexMethod indexMethod)
     {
         checkMutability();
         if (spatialColumns != Spatial.LAT_LON_DIMENSIONS && spatialColumns != 1) {
@@ -162,8 +157,7 @@ public abstract class Index extends HasStorage implements Visitable, Constraint
         this.firstSpatialArgument = firstSpatialArgument;
         this.lastSpatialArgument = firstSpatialArgument + spatialColumns - 1;
         this.space = Spatial.createLatLonSpace();
-        this.functionName = functionName;
-        this.indexMethod = IndexMethod.valueOf(functionName.trim().toUpperCase());
+        this.indexMethod = indexMethod;
     }
 
     public int firstSpatialArgument()
@@ -387,7 +381,6 @@ public abstract class Index extends HasStorage implements Visitable, Constraint
     private volatile TInstance[] types;
     private TableName constraintName;
     private IndexMethod indexMethod;
-    private String functionName;
     // For a spatial index
     private Space space;
     private int firstSpatialArgument;

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/ais/model/TableIndex.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/ais/model/TableIndex.java
@@ -68,7 +68,7 @@ public class TableIndex extends Index
                                   index.isUnique(),
                                   index.isPrimaryKey(), index.getConstraintName());
         if (index.isSpatial()) {
-            copy.markSpatial(index.firstSpatialArgument(), index.spatialColumns(), index.functionName());
+            copy.markSpatial(index.firstSpatialArgument(), index.spatialColumns(), index.getIndexMethod());
         }
         return copy;
     }

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/ais/model/TableIndex.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/ais/model/TableIndex.java
@@ -67,8 +67,8 @@ public class TableIndex extends Index
         TableIndex copy = create(table.getAIS(), table, index.getIndexName().getName(), index.getIndexId(),
                                   index.isUnique(),
                                   index.isPrimaryKey(), index.getConstraintName());
-        if (index.getIndexMethod() == IndexMethod.Z_ORDER_LAT_LON) {
-            copy.markSpatial(index.firstSpatialArgument(), index.spatialColumns());
+        if (index.isSpatial()) {
+            copy.markSpatial(index.firstSpatialArgument(), index.spatialColumns(), index.functionName());
         }
         return copy;
     }

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/ais/protobuf/ProtobufReader.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/ais/protobuf/ProtobufReader.java
@@ -499,7 +499,8 @@ public class ProtobufReader {
                             lastSpatialArg = firstSpatialArg + pbIndex.getDimensions() - 1;
                         }
                     }
-                    index.markSpatial(firstSpatialArg, lastSpatialArg - firstSpatialArg + 1, pbIndex.getFunctionName());
+                    index.markSpatial(firstSpatialArg, lastSpatialArg - firstSpatialArg + 1,
+                                      Index.IndexMethod.valueOf(pbIndex.getIndexMethod().name()));
                     break;
             }
         }
@@ -830,8 +831,7 @@ public class ProtobufReader {
                 AISProtobuf.Index.LASTSPATIALARG_FIELD_NUMBER,
                 AISProtobuf.Index.DIMENSIONS_FIELD_NUMBER,
                 AISProtobuf.Index.STORAGE_FIELD_NUMBER,
-                AISProtobuf.Index.CONSTRAINTNAME_FIELD_NUMBER,
-                AISProtobuf.Index.FUNCTIONNAME_FIELD_NUMBER
+                AISProtobuf.Index.CONSTRAINTNAME_FIELD_NUMBER
         );
     }
 
@@ -844,8 +844,7 @@ public class ProtobufReader {
                 AISProtobuf.Index.LASTSPATIALARG_FIELD_NUMBER,
                 AISProtobuf.Index.DIMENSIONS_FIELD_NUMBER,
                 AISProtobuf.Index.STORAGE_FIELD_NUMBER,
-                AISProtobuf.Index.CONSTRAINTNAME_FIELD_NUMBER,
-                AISProtobuf.Index.FUNCTIONNAME_FIELD_NUMBER
+                AISProtobuf.Index.CONSTRAINTNAME_FIELD_NUMBER
         );
     }
 

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/ais/protobuf/ProtobufReader.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/ais/protobuf/ProtobufReader.java
@@ -486,22 +486,20 @@ public class ProtobufReader {
     private void handleSpatial(Index index, AISProtobuf.Index pbIndex) {
         if (pbIndex.hasIndexMethod()) {
             switch (pbIndex.getIndexMethod()) {
-                case Z_ORDER_LAT_LON:
+                case GEO_LAT_LON:
                     assert pbIndex.hasFirstSpatialArg() == pbIndex.hasDimensions();
                     int firstSpatialArg = 0;
                     int lastSpatialArg = 0;
-                    int dimensions = Spatial.LAT_LON_DIMENSIONS;
                     if (pbIndex.hasFirstSpatialArg()) {
                         firstSpatialArg = pbIndex.getFirstSpatialArg();
-                        dimensions = pbIndex.getDimensions();
                         if (pbIndex.hasLastSpatialArg()) {
                             lastSpatialArg = pbIndex.getLastSpatialArg();
                         } else {
                             // Schema created before spatial object support, when spatial meant just lat/lon.
-                            lastSpatialArg = firstSpatialArg + dimensions - 1;
+                            lastSpatialArg = firstSpatialArg + pbIndex.getDimensions() - 1;
                         }
                     }
-                    index.markSpatial(firstSpatialArg, lastSpatialArg - firstSpatialArg + 1);
+                    index.markSpatial(firstSpatialArg, lastSpatialArg - firstSpatialArg + 1, pbIndex.getFunctionName());
                     break;
             }
         }
@@ -832,7 +830,8 @@ public class ProtobufReader {
                 AISProtobuf.Index.LASTSPATIALARG_FIELD_NUMBER,
                 AISProtobuf.Index.DIMENSIONS_FIELD_NUMBER,
                 AISProtobuf.Index.STORAGE_FIELD_NUMBER,
-                AISProtobuf.Index.CONSTRAINTNAME_FIELD_NUMBER
+                AISProtobuf.Index.CONSTRAINTNAME_FIELD_NUMBER,
+                AISProtobuf.Index.FUNCTIONNAME_FIELD_NUMBER
         );
     }
 
@@ -845,7 +844,8 @@ public class ProtobufReader {
                 AISProtobuf.Index.LASTSPATIALARG_FIELD_NUMBER,
                 AISProtobuf.Index.DIMENSIONS_FIELD_NUMBER,
                 AISProtobuf.Index.STORAGE_FIELD_NUMBER,
-                AISProtobuf.Index.CONSTRAINTNAME_FIELD_NUMBER
+                AISProtobuf.Index.CONSTRAINTNAME_FIELD_NUMBER,
+                AISProtobuf.Index.FUNCTIONNAME_FIELD_NUMBER
         );
     }
 

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/ais/protobuf/ProtobufWriter.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/ais/protobuf/ProtobufWriter.java
@@ -526,8 +526,7 @@ public class ProtobufWriter {
             indexBuilder.
                     setFirstSpatialArg(index.firstSpatialArgument()).
                     setLastSpatialArg(index.lastSpatialArgument()).
-                    setDimensions(index.dimensions()).
-                    setFunctionName(index.functionName());
+                    setDimensions(index.dimensions());
 
         }
 

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/ais/protobuf/ProtobufWriter.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/ais/protobuf/ProtobufWriter.java
@@ -522,11 +522,12 @@ public class ProtobufWriter {
             index.getStorageDescription().writeProtobuf(storageBuilder);
             indexBuilder.setStorage(storageBuilder.build());
         }
-        if (index.getIndexMethod() == Index.IndexMethod.Z_ORDER_LAT_LON) {
+        if (index.getIndexMethod() == Index.IndexMethod.GEO_LAT_LON) {
             indexBuilder.
                     setFirstSpatialArg(index.firstSpatialArgument()).
                     setLastSpatialArg(index.lastSpatialArgument()).
-                    setDimensions(index.dimensions());
+                    setDimensions(index.dimensions()).
+                    setFunctionName(index.functionName());
 
         }
 
@@ -604,8 +605,8 @@ public class ProtobufWriter {
         case NORMAL: 
         default:
             return AISProtobuf.IndexMethod.NORMAL;
-        case Z_ORDER_LAT_LON: 
-            return AISProtobuf.IndexMethod.Z_ORDER_LAT_LON;
+        case GEO_LAT_LON:
+            return AISProtobuf.IndexMethod.GEO_LAT_LON;
         case FULL_TEXT: 
             return AISProtobuf.IndexMethod.FULL_TEXT;
         }

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/error/ErrorCode.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/error/ErrorCode.java
@@ -373,6 +373,7 @@ public enum ErrorCode {
     DUPLICATE_PARAMETER     ("50", "00X", Importance.DEBUG, DuplicateParameterNameException.class),
     SET_STORAGE_NOT_ROOT    ("50", "00Y", Importance.DEBUG, SetStorageNotRootException.class),
     INVALID_CREATE_AS       ("50", "00Z", Importance.DEBUG, InvalidCreateAsException.class),
+    UNSUPPORTED_FUNCTION_IN_INDEX("50", "040", Importance.DEBUG, UnsupportedFunctionInIndexException.class),
 
     // AIS Validation errors, Attempts to modify and build an AIS failed
     // due to missing or invalid information.

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/error/UnsupportedFunctionInIndexException.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/error/UnsupportedFunctionInIndexException.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (C) 2009-2013 FoundationDB, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.foundationdb.server.error;
+
+public class UnsupportedFunctionInIndexException extends InvalidOperationException {
+    public UnsupportedFunctionInIndexException(String name) {
+        super (ErrorCode.UNSUPPORTED_FUNCTION_IN_INDEX, name);
+    }
+}

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/error/UnsupportedFunctionInIndexException.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/error/UnsupportedFunctionInIndexException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2009-2013 FoundationDB, LLC
+ * Copyright (C) 2009-2015 FoundationDB, LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/sql/aisddl/IndexDDL.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/sql/aisddl/IndexDDL.java
@@ -17,9 +17,7 @@
 
 package com.foundationdb.sql.aisddl;
 
-import java.util.Collection;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 
 import com.foundationdb.ais.AISCloner;
@@ -162,18 +160,23 @@ public class IndexDDL
         if (createIndex.isUnique()) {
             constraintName = builder.getNameGenerator().generateUniqueConstraintName(schemaName, indexName);
         }
-        if (createIndex.getIndexColumnList().functionType() == IndexColumnList.FunctionType.FULL_TEXT) {
+        IndexColumnList indexColumnList = createIndex.getIndexColumnList();
+        String functionName = indexColumnList.functionName();
+        checkFunctionNameValidity(functionName);
+        if (isFullText(functionName)) {
             logger.debug ("Building Full text index on table {}", tableName) ;
-            index = buildFullTextIndex (builder, tableName, indexName, createIndex, createIndex.getExistenceCheck(), context);
+            index = buildFullTextIndex(builder, tableName, indexName, createIndex, createIndex
+                .getExistenceCheck(), context);
         } else if (checkIndexType (createIndex, tableName) == Index.IndexType.TABLE) {
             logger.debug ("Building Table index on table {}", tableName) ;
-            index = buildTableIndex (builder, tableName, indexName, createIndex, constraintName, createIndex.getExistenceCheck(), context);
+            index = buildTableIndex(builder, tableName, indexName, createIndex, constraintName, createIndex
+                .getExistenceCheck(), context);
         } else {
             logger.debug ("Building Group index on table {}", tableName);
             index = buildGroupIndex (builder, tableName, indexName, createIndex, createIndex.getExistenceCheck(), context);
         }
         if(index != null) {
-            boolean indexIsSpatial = createIndex.getIndexColumnList().functionType() == IndexColumnList.FunctionType.Z_ORDER_LAT_LON;
+            boolean indexIsSpatial = isSpatial(functionName);
             // Can't check isSpatialCompatible before the index columns have been added.
             if(indexIsSpatial && !Index.isSpatialCompatible(index)) {
                 throw new BadSpatialIndexException(index.getIndexName().getTableName(), createIndex);
@@ -243,9 +246,11 @@ public class IndexDDL
                       false, constraintName);
         TableIndex tableIndex = builder.akibanInformationSchema().getTable(tableName).getIndex(indexName);
         IndexColumnList indexColumns = index.getIndexColumnList();
-        if (indexColumns.functionType() == IndexColumnList.FunctionType.Z_ORDER_LAT_LON) {
+        String functionName = indexColumns.functionName();
+        if (isSpatial(functionName)) {
             tableIndex.markSpatial(indexColumns.firstFunctionArg(),
-                                   indexColumns.lastFunctionArg() + 1 - indexColumns.firstFunctionArg());
+                                   indexColumns.lastFunctionArg() + 1 - indexColumns.firstFunctionArg(),
+                                   functionName);
         }
         int i = 0;
         for (IndexColumn col : indexColumns) {
@@ -311,10 +316,11 @@ public class IndexDDL
         builder.groupIndex(groupName, indexName, index.isUnique(), joinType);
         GroupIndex groupIndex = builder.akibanInformationSchema().getGroup(groupName).getIndex(indexName);
         IndexColumnList indexColumns = index.getIndexColumnList();
-        boolean indexIsSpatial = indexColumns.functionType() == IndexColumnList.FunctionType.Z_ORDER_LAT_LON;
+        boolean indexIsSpatial = isSpatial(indexColumns.functionName());
         if (indexIsSpatial) {
             groupIndex.markSpatial(indexColumns.firstFunctionArg(),
-                                   indexColumns.lastFunctionArg() + 1 - indexColumns.firstFunctionArg());
+                                   indexColumns.lastFunctionArg() + 1 - indexColumns.firstFunctionArg(),
+                                   indexColumns.functionName());
         }
         int i = 0;
         String schemaName;
@@ -404,6 +410,23 @@ public class IndexDDL
             i++;
         }
         return builder.akibanInformationSchema().getTable(tableName).getFullTextIndex(indexName);
+    }
+
+    static boolean isSpatial(String functionName)
+    {
+        return functionName != null && functionName.equalsIgnoreCase(Index.IndexMethod.GEO_LAT_LON.name());
+    }
+
+    static boolean isFullText(String functionName)
+    {
+        return functionName != null && functionName.equalsIgnoreCase(Index.IndexMethod.FULL_TEXT.name());
+    }
+
+    static void checkFunctionNameValidity(String functionName)
+    {
+        if (functionName != null && !isSpatial(functionName) && !isFullText(functionName)) {
+            throw new UnsupportedFunctionInIndexException(functionName);
+        }
     }
 
     private static void clone(AISCloner aisCloner, AISBuilder builder, AkibanInformationSchema ais) {

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/sql/aisddl/IndexDDL.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/sql/aisddl/IndexDDL.java
@@ -250,7 +250,7 @@ public class IndexDDL
         if (isSpatial(functionName)) {
             tableIndex.markSpatial(indexColumns.firstFunctionArg(),
                                    indexColumns.lastFunctionArg() + 1 - indexColumns.firstFunctionArg(),
-                                   functionName);
+                                   Index.IndexMethod.valueOf(functionName.trim().toUpperCase()));
         }
         int i = 0;
         for (IndexColumn col : indexColumns) {
@@ -320,7 +320,7 @@ public class IndexDDL
         if (indexIsSpatial) {
             groupIndex.markSpatial(indexColumns.firstFunctionArg(),
                                    indexColumns.lastFunctionArg() + 1 - indexColumns.firstFunctionArg(),
-                                   indexColumns.functionName());
+                                   Index.IndexMethod.valueOf(indexColumns.functionName().trim().toUpperCase()));
         }
         int i = 0;
         String schemaName;

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/sql/aisddl/TableDDL.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/sql/aisddl/TableDDL.java
@@ -646,7 +646,9 @@ public class TableDDL
         if(id.isUnique()) {
             constraintName = builder.getNameGenerator().generateUniqueConstraintName(table.getName().getSchemaName(), indexName);
         }
-        if (columnList.functionType() == IndexColumnList.FunctionType.FULL_TEXT) {
+        String functionName = columnList.functionName();
+        IndexDDL.checkFunctionNameValidity(functionName);
+        if (IndexDDL.isFullText(functionName)) {
             logger.debug ("Building Full text index on table {}", table.getName()) ;
             tableIndex = IndexDDL.buildFullTextIndex(builder, table.getName(), indexName, id, null, null);
         } else if (IndexDDL.checkIndexType (id, table.getName()) == Index.IndexType.TABLE) {
@@ -657,7 +659,7 @@ public class TableDDL
             tableIndex = IndexDDL.buildGroupIndex(builder, table.getName(), indexName, id, null, null);
         }
 
-        boolean indexIsSpatial = columnList.functionType() == IndexColumnList.FunctionType.Z_ORDER_LAT_LON;
+        boolean indexIsSpatial = IndexDDL.isSpatial(functionName);
         // Can't check isSpatialCompatible before the index columns have been added.
         if (indexIsSpatial && !Index.isSpatialCompatible(tableIndex)) {
             throw new BadSpatialIndexException(tableIndex.getIndexName().getTableName(), null);

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/sql/optimizer/rule/join_enum/GroupIndexGoal.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/sql/optimizer/rule/join_enum/GroupIndexGoal.java
@@ -46,7 +46,6 @@ import com.google.common.base.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.sql.Types;
 import java.util.*;
 
 /** The goal of a indexes within a group. */
@@ -407,7 +406,7 @@ public class GroupIndexGoal implements Comparator<BaseScan>
         int firstSpatialColumn, spatialColumns;
         SpecialIndexExpression.Function spatialFunction;
         switch (aisIndex.getIndexMethod()) {
-        case Z_ORDER_LAT_LON:
+        case GEO_LAT_LON:
             firstSpatialColumn = aisIndex.firstSpatialArgument();
             spatialColumns = aisIndex.spatialColumns();
             if (spatialColumns == Spatial.LAT_LON_DIMENSIONS)

--- a/fdb-sql-layer-core/src/main/protobuf/akiban_information_schema.proto
+++ b/fdb-sql-layer-core/src/main/protobuf/akiban_information_schema.proto
@@ -55,7 +55,7 @@ message Sequence {
 
 enum IndexMethod {
    NORMAL          = 0;                  // Regular column index.
-   Z_ORDER_LAT_LON = 1;                  // Spatial index on latitude, longitude.
+   GEO_LAT_LON     = 1;                  // Spatial index on latitude, longitude.
    FULL_TEXT       = 2;                  // Lucene full index text.
 }
 
@@ -87,6 +87,7 @@ message Index {
     optional Storage storage     = 13;  // storage description
 	optional TableName constraintName = 14; // name for constraint
     optional int32 lastSpatialArg = 15;    // For a spatial index, the position in the index of the last spatial column
+    optional string functionName = 16;  // The name of a function used in an index declaration
 }
 
 message Group {

--- a/fdb-sql-layer-core/src/main/protobuf/akiban_information_schema.proto
+++ b/fdb-sql-layer-core/src/main/protobuf/akiban_information_schema.proto
@@ -87,7 +87,6 @@ message Index {
     optional Storage storage     = 13;  // storage description
 	optional TableName constraintName = 14; // name for constraint
     optional int32 lastSpatialArg = 15;    // For a spatial index, the position in the index of the last spatial column
-    optional string functionName = 16;  // The name of a function used in an index declaration
 }
 
 message Group {

--- a/fdb-sql-layer-core/src/main/resources/com/foundationdb/server/error/error_code.properties
+++ b/fdb-sql-layer-core/src/main/resources/com/foundationdb/server/error/error_code.properties
@@ -234,6 +234,7 @@ DUPLICATE_PARAMETER         = Procedure `{0}`.`{1}` already has parameter `{2}`
 SET_STORAGE_NOT_ROOT        = Cannot specify storage for table `{0}`.`{1}` which is not the root table of the group
 INVALID_CREATE_AS           = Cannot create table due to illegal create as query: {0}
 DUPLICATE_CONSTRAINTNAME    = Schema `{0}` already contains a constraint named `{1}`
+UNSUPPORTED_FUNCTION_IN_INDEX = `{0}` is not a function whose value can be indexed
 
 
 #

--- a/fdb-sql-layer-core/src/test/java/com/foundationdb/server/test/ApiTestBase.java
+++ b/fdb-sql-layer-core/src/test/java/com/foundationdb/server/test/ApiTestBase.java
@@ -630,7 +630,7 @@ public class ApiTestBase {
         StringBuilder cols = new StringBuilder();
         for (int i = 0; i < indexCols.length; i++) {
             if (i > 0) cols.append(",");
-            if (i == firstSpatialArgument) cols.append("Z_ORDER_LAT_LON(");
+            if (i == firstSpatialArgument) cols.append("GEO_LAT_LON(");
             cols.append(indexCols[i]);
             if (i == firstSpatialArgument + spatialColumns - 1) cols.append(")");
         }
@@ -688,7 +688,7 @@ public class ApiTestBase {
                 ddl.append(",");
             }
             if(i == firstSpatialIndex) {
-                ddl.append("Z_ORDER_LAT_LON(");
+                ddl.append("GEO_LAT_LON(");
             }
             ddl.append(columnNames[i]);
             if(i == lastSpatialIndex) {

--- a/fdb-sql-layer-core/src/test/java/com/foundationdb/server/test/it/bugs/bug1047046/AlterColumnInSpatialIndexIT.java
+++ b/fdb-sql-layer-core/src/test/java/com/foundationdb/server/test/it/bugs/bug1047046/AlterColumnInSpatialIndexIT.java
@@ -37,7 +37,7 @@ public class AlterColumnInSpatialIndexIT extends AlterTableITBase {
                 row(tid, "32.456", "99.543"),
                 row(tid, "53.00", "80.00")
         );
-        createIndex(SCHEMA, TABLE, INDEX_NAME, "z_order_lat_lon(c1, c2)");
+        createIndex(SCHEMA, TABLE, INDEX_NAME, "geo_lat_lon(c1, c2)");
         TableIndex index = getTable(tid).getIndex("idx1");
         assertNotNull("Found index", index);
         assertEquals("Is spatial", true, index.isSpatial());

--- a/fdb-sql-layer-core/src/test/java/com/foundationdb/sql/aisddl/IndexDDLIT.java
+++ b/fdb-sql-layer-core/src/test/java/com/foundationdb/sql/aisddl/IndexDDLIT.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import com.foundationdb.server.error.UnsupportedFunctionInIndexException;
 import org.junit.Test;
 
 import com.foundationdb.ais.model.FullTextIndex;
@@ -365,12 +366,18 @@ public class IndexDDLIT extends AISDDLITBase {
     public void createSpatialIndex() throws Exception {
         String sql = "CREATE TABLE test.t16 (c1 decimal(11,7), c2 decimal(11,7))";
         executeDDL(sql);
-        sql = "CREATE INDEX t16_space on test.t16(z_order_lat_lon(c1, c2))";
+        sql = "CREATE INDEX t16_space on test.t16(geo_lat_lon(c1, c2))";
         executeDDL(sql);
         TableIndex index = ais().getTable("test", "t16").getIndex("t16_space");
         assertNotNull(index);
         assertTrue(index.isSpatial());
         
+    }
+
+    @Test (expected=UnsupportedFunctionInIndexException.class)
+    public void createIndexWithUnsupportedFunction() throws Exception {
+        executeDDL("create table t(x decimal(10, 5), y decimal(10, 5))");
+        executeDDL("create index t_z_order_lat_lon_is_oldspeak on t(z_order_lat_lon(x, y))");
     }
     
     @Test

--- a/fdb-sql-layer-core/src/test/java/com/foundationdb/sql/aisddl/TableDDLIT.java
+++ b/fdb-sql-layer-core/src/test/java/com/foundationdb/sql/aisddl/TableDDLIT.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 import com.foundationdb.ais.model.ForeignKey;
+import com.foundationdb.server.error.UnsupportedFunctionInIndexException;
 import com.foundationdb.server.error.UnsupportedSQLException;
 
 import org.junit.Test;
@@ -423,7 +424,7 @@ public class TableDDLIT extends AISDDLITBase {
 
     @Test
     public void createSpatialIndexTable() throws Exception {
-        String sql = "CREATE TABLE test.t16 (c1 decimal(11,7), c2 decimal(11,7), INDEX idx1 (z_order_lat_lon(c1, c2)))";
+        String sql = "CREATE TABLE test.t16 (c1 decimal(11,7), c2 decimal(11,7), INDEX idx1 (geo_lat_lon(c1, c2)))";
         executeDDL (sql);
         Table table = ais().getTable("test", "t16");
         TableIndex index = table.getIndex("idx1");
@@ -433,6 +434,13 @@ public class TableDDLIT extends AISDDLITBase {
         assertTrue (index.isSpatial());
     }
     
+    @Test (expected=UnsupportedFunctionInIndexException.class)
+    public void createIndexWithUnsupportedFunction() throws Exception {
+        // z_order_lat_lon is no longer supported, use geo_lat_lon instead
+        String sql = "CREATE TABLE test.t16 (c1 decimal(11,7), c2 decimal(11,7), INDEX idx1 (z_order_lat_lon(c1, c2)))";
+        executeDDL(sql);
+    }
+
     @Test
     public void testCreateNationalChar() throws Exception {
         String sql1 = "CREATE TABLE test.T1 (c1 NATIONAL CHAR(10), c2 NATIONAL CHARACTER VARYING(10), c3 LONG NVARCHAR) ";

--- a/fdb-sql-layer-core/src/test/resources/com/foundationdb/sql/optimizer/rule/operator/geospatial-1.ddl
+++ b/fdb-sql-layer-core/src/test/resources/com/foundationdb/sql/optimizer/rule/operator/geospatial-1.ddl
@@ -7,4 +7,4 @@ CREATE TABLE places
   lon DECIMAL(8,4)
 );
 
-CREATE INDEX places_geo ON places(z_order_lat_lon(lat, lon));
+CREATE INDEX places_geo ON places(geo_lat_lon(lat, lon));

--- a/fdb-sql-layer-core/src/test/resources/com/foundationdb/sql/optimizer/rule/operator/geospatial-2.ddl
+++ b/fdb-sql-layer-core/src/test/resources/com/foundationdb/sql/optimizer/rule/operator/geospatial-2.ddl
@@ -7,4 +7,4 @@ CREATE TABLE places
   lon DECIMAL(8,4)
 );
 
-CREATE INDEX places_geo ON places(z_order_lat_lon(lat, lon));
+CREATE INDEX places_geo ON places(geo_lat_lon(lat, lon));

--- a/fdb-sql-layer-core/src/test/resources/com/foundationdb/sql/optimizer/rule/operator/geospatial-3.ddl
+++ b/fdb-sql-layer-core/src/test/resources/com/foundationdb/sql/optimizer/rule/operator/geospatial-3.ddl
@@ -7,4 +7,4 @@ CREATE TABLE places
   lon DECIMAL(8,4)
 );
 
-CREATE INDEX places_geo ON places(state, z_order_lat_lon(lat, lon), lat, lon);
+CREATE INDEX places_geo ON places(state, geo_lat_lon(lat, lon), lat, lon);

--- a/fdb-sql-layer-core/src/test/resources/com/foundationdb/sql/optimizer/rule/operator/geospatial-4.ddl
+++ b/fdb-sql-layer-core/src/test/resources/com/foundationdb/sql/optimizer/rule/operator/geospatial-4.ddl
@@ -17,7 +17,7 @@ CREATE TABLE food_vendors(
 CREATE INDEX name_geo ON food_vendors(
     places.state,
     food_vendors.name,
-    z_order_lat_lon(places.lat, places.lon),
+    geo_lat_lon(places.lat, places.lon),
     places.lat,
     places.lon
 ) using left join;

--- a/fdb-sql-layer-core/src/test/resources/com/foundationdb/sql/optimizer/rule/operator/geospatial-5.ddl
+++ b/fdb-sql-layer-core/src/test/resources/com/foundationdb/sql/optimizer/rule/operator/geospatial-5.ddl
@@ -7,4 +7,4 @@ CREATE TABLE places
   lon DECIMAL(8,4)
 );
 
-CREATE INDEX places_geo ON places(z_order_lat_lon(lat, lon));
+CREATE INDEX places_geo ON places(geo_lat_lon(lat, lon));

--- a/fdb-sql-layer-core/src/test/resources/com/foundationdb/sql/optimizer/rule/operator/geospatial-6.ddl
+++ b/fdb-sql-layer-core/src/test/resources/com/foundationdb/sql/optimizer/rule/operator/geospatial-6.ddl
@@ -6,4 +6,4 @@ CREATE TABLE places
   shape BLOB
 );
 
-CREATE INDEX places_geo ON places(z_order_lat_lon(shape));
+CREATE INDEX places_geo ON places(geo_lat_lon(shape));

--- a/fdb-sql-layer-core/src/test/resources/com/foundationdb/sql/optimizer/rule/pick-joins-and-indexes/geospatial-1.ddl
+++ b/fdb-sql-layer-core/src/test/resources/com/foundationdb/sql/optimizer/rule/pick-joins-and-indexes/geospatial-1.ddl
@@ -7,4 +7,4 @@ CREATE TABLE places
   lon DECIMAL(8,4)
 );
 
-CREATE INDEX places_geo ON places(z_order_lat_lon(lat, lon));
+CREATE INDEX places_geo ON places(geo_lat_lon(lat, lon));

--- a/fdb-sql-layer-core/src/test/resources/com/foundationdb/sql/optimizer/rule/pick-joins-and-indexes/geospatial-2.ddl
+++ b/fdb-sql-layer-core/src/test/resources/com/foundationdb/sql/optimizer/rule/pick-joins-and-indexes/geospatial-2.ddl
@@ -7,4 +7,4 @@ CREATE TABLE places
   lon DECIMAL(8,4)
 );
 
-CREATE INDEX places_geo ON places(z_order_lat_lon(lat, lon));
+CREATE INDEX places_geo ON places(geo_lat_lon(lat, lon));

--- a/fdb-sql-layer-core/src/test/resources/com/foundationdb/sql/optimizer/rule/pick-joins-and-indexes/geospatial-3.ddl
+++ b/fdb-sql-layer-core/src/test/resources/com/foundationdb/sql/optimizer/rule/pick-joins-and-indexes/geospatial-3.ddl
@@ -7,4 +7,4 @@ CREATE TABLE places
   lon DECIMAL(8,4)
 );
 
-CREATE INDEX places_geo ON places(state, z_order_lat_lon(lat, lon), lat, lon);
+CREATE INDEX places_geo ON places(state, geo_lat_lon(lat, lon), lat, lon);

--- a/fdb-sql-layer-core/src/test/resources/com/foundationdb/sql/optimizer/rule/pick-joins-and-indexes/geospatial-3n.ddl
+++ b/fdb-sql-layer-core/src/test/resources/com/foundationdb/sql/optimizer/rule/pick-joins-and-indexes/geospatial-3n.ddl
@@ -7,4 +7,4 @@ CREATE TABLE places
   lon DECIMAL(8,4)
 );
 
-CREATE INDEX places_geo ON places(state, z_order_lat_lon(lat, lon), lat, lon);
+CREATE INDEX places_geo ON places(state, geo_lat_lon(lat, lon), lat, lon);

--- a/fdb-sql-layer-core/src/test/resources/com/foundationdb/sql/optimizer/rule/pick-joins-and-indexes/geospatial-4.ddl
+++ b/fdb-sql-layer-core/src/test/resources/com/foundationdb/sql/optimizer/rule/pick-joins-and-indexes/geospatial-4.ddl
@@ -7,5 +7,5 @@ CREATE TABLE places
   lon DECIMAL(8,4)
 );
 
-CREATE INDEX places_geo_1 ON places(state, z_order_lat_lon(lat, lon), lat, lon);
-CREATE INDEX places_geo_2 ON places(city, z_order_lat_lon(lat, lon), lat, lon);
+CREATE INDEX places_geo_1 ON places(state, geo_lat_lon(lat, lon), lat, lon);
+CREATE INDEX places_geo_2 ON places(city, geo_lat_lon(lat, lon), lat, lon);

--- a/fdb-sql-layer-core/src/test/resources/com/foundationdb/sql/optimizer/rule/pick-joins-and-indexes/geospatial-5.ddl
+++ b/fdb-sql-layer-core/src/test/resources/com/foundationdb/sql/optimizer/rule/pick-joins-and-indexes/geospatial-5.ddl
@@ -7,4 +7,4 @@ CREATE TABLE places
   lon DECIMAL(8,4)
 );
 
-CREATE INDEX places_geo ON places(z_order_lat_lon(lat, lon))
+CREATE INDEX places_geo ON places(geo_lat_lon(lat, lon))

--- a/fdb-sql-layer-core/src/test/resources/com/foundationdb/sql/optimizer/rule/pick-joins-and-indexes/geospatial-6.ddl
+++ b/fdb-sql-layer-core/src/test/resources/com/foundationdb/sql/optimizer/rule/pick-joins-and-indexes/geospatial-6.ddl
@@ -6,4 +6,4 @@ CREATE TABLE places
   shape BLOB
 );
 
-CREATE INDEX places_geo ON places(z_order_lat_lon(shape));
+CREATE INDEX places_geo ON places(geo_lat_lon(shape));

--- a/fdb-sql-layer-pg/src/main/java/com/foundationdb/sql/pg/PostgresEmulatedMetaDataStatement.java
+++ b/fdb-sql-layer-pg/src/main/java/com/foundationdb/sql/pg/PostgresEmulatedMetaDataStatement.java
@@ -1262,7 +1262,7 @@ public class PostgresEmulatedMetaDataStatement implements PostgresStatement
         switch (index.getIndexMethod()) {
         case NORMAL:
             break;
-        case Z_ORDER_LAT_LON:
+        case GEO_LAT_LON:
             firstFunctionColumn = index.firstSpatialArgument();
             lastFunctionColumn = firstFunctionColumn + index.spatialColumns() - 1;
             break;

--- a/fdb-sql-layer-test-yaml/src/test/resources/com/foundationdb/sql/test/yaml/functional/test-spatial-index.yaml
+++ b/fdb-sql-layer-test-yaml/src/test/resources/com/foundationdb/sql/test/yaml/functional/test-spatial-index.yaml
@@ -10,9 +10,9 @@
      f double,
      g blob)
 ---
-- Statement: CREATE INDEX idx_ab ON t(z_order_lat_lon(a, b))
+- Statement: CREATE INDEX idx_ab ON t(geo_lat_lon(a, b))
 ---
-- Statement: CREATE INDEX idx_cd ON t(z_order_lat_lon(c, d))
+- Statement: CREATE INDEX idx_cd ON t(geo_lat_lon(c, d))
 ---
-- Statement: CREATE INDEX idx_ef ON t(z_order_lat_lon(e, f))
+- Statement: CREATE INDEX idx_ef ON t(geo_lat_lon(e, f))
 - error: [5000V]


### PR DESCRIPTION
This is the sql-layer side of the slight generalization of support for functions in indexes. 

I have kept the enum, but added functionName to Index in ais.proto. The enum would work by itself except for getting case sensitivity correct. I'll remove it if anyone thinks this is pointless right now.

Tests run cleanly except as noted in recent email: some tests in fdb-sql-layer-pg are failing. Mike says these are known to occur occasionally, and they do seem far from my changes.