### PR TITLE
Get rid of TExecutionContext#inputTypeAt

### DIFF
--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/TClassBase.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/TClassBase.java
@@ -77,7 +77,7 @@ public abstract class TClassBase extends TClass
                     sb = (StringBuilder) appender.getAppendable();
                     sb.setLength(0);
                 }
-                format(context.inputTypeAt(0), source, appender);
+                format(source.getType(), source, appender);
                 String string = sb.toString();
                 int maxlen = context.outputType().attribute(StringAttribute.MAX_LENGTH);
                 String trunc = Strings.truncateIfNecessary(string, maxlen);

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/TExecutionContext.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/TExecutionContext.java
@@ -35,10 +35,6 @@ import java.util.Locale;
 
 public final class TExecutionContext {
 
-    public TInstance inputTypeAt(int index) {
-        return inputTypes.get(index);
-    }
-
     public Object objectAt(int index) {
         Object result = null;
         if (preptimeCache != null && preptimeCache.isDefined(index))

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/common/funcs/Base64.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/common/funcs/Base64.java
@@ -111,8 +111,9 @@ public class Base64
             protected void doEvaluate(TExecutionContext context,
                                       LazyList<? extends ValueSource> inputs,
                                       ValueTarget output) {
-                String charset = StringFactory.Charset.of(context.inputTypeAt(0).attribute(StringAttribute.CHARSET));
-                String string = inputs.get(0).getString();
+                ValueSource input = inputs.get(0);
+                String charset = StringFactory.Charset.of(input.getType().attribute(StringAttribute.CHARSET));
+                String string = input.getString();
                 try {
                     byte[] binary = string.getBytes(charset);
                     output.putString(Strings.toBase64(binary), null);

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/common/funcs/DescribeExpression.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/common/funcs/DescribeExpression.java
@@ -47,9 +47,9 @@ public final class DescribeExpression extends TScalarBase {
 
     @Override
     protected void doEvaluate(TExecutionContext context, LazyList<? extends ValueSource> inputs, ValueTarget output) {
-        String result = context.inputTypeAt(0).toString();
         ValueSource input = inputs.get(0);
-        result = ( (input== null) ? "variable " : "const ") + result;
+        String result = input.getType().toString();
+        result = ((input.isNull()) ? "variable " : "const ") + result;
         output.putString(result, null);
     }
 

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/common/funcs/DistanceLatLon.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/common/funcs/DistanceLatLon.java
@@ -56,10 +56,15 @@ public class DistanceLatLon extends TScalarBase
     @Override
     protected void doEvaluate(TExecutionContext context, LazyList<? extends ValueSource> inputs, ValueTarget output)
     {
-        double y1 = doubleInRange(TBigDecimal.getWrapper(inputs.get(0), context.inputTypeAt(0)), MIN_LAT, MAX_LAT);
-        double x1 = doubleInRange(TBigDecimal.getWrapper(inputs.get(1), context.inputTypeAt(1)), MIN_LON, MAX_LON);
-        double y2 = doubleInRange(TBigDecimal.getWrapper(inputs.get(2), context.inputTypeAt(2)), MIN_LAT, MAX_LAT);
-        double x2 = doubleInRange(TBigDecimal.getWrapper(inputs.get(3), context.inputTypeAt(3)), MIN_LON, MAX_LON);
+        ValueSource input0 = inputs.get(0);
+        ValueSource input1 = inputs.get(1);
+        ValueSource input2 = inputs.get(2);
+        ValueSource input3 = inputs.get(3);
+
+        double y1 = doubleInRange(TBigDecimal.getWrapper(input0, input0.getType()), MIN_LAT, MAX_LAT);
+        double x1 = doubleInRange(TBigDecimal.getWrapper(input1, input1.getType()), MIN_LON, MAX_LON);
+        double y2 = doubleInRange(TBigDecimal.getWrapper(input2, input2.getType()), MIN_LAT, MAX_LAT);
+        double x2 = doubleInRange(TBigDecimal.getWrapper(input3, input3.getType()), MIN_LON, MAX_LON);
         
         double dx = Math.abs(x1 - x2);
         // we want the shorter distance of the two

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/common/funcs/GeoLatLon.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/common/funcs/GeoLatLon.java
@@ -59,9 +59,12 @@ public class GeoLatLon extends TScalarBase
 
     @Override
     protected void doEvaluate(TExecutionContext context, LazyList<? extends ValueSource> inputs, ValueTarget output) {
+        ValueSource input0 = inputs.get(0);
+        ValueSource input1 = inputs.get(1);
+
         GeometryFactory factory = (GeometryFactory)context.preptimeObjectAt(FACTORY_CONTEXT_POS);
-        double lat = doubleInRange(TBigDecimal.getWrapper(inputs.get(0), context.inputTypeAt(0)), MIN_LAT, MAX_LAT);
-        double lon = doubleInRange(TBigDecimal.getWrapper(inputs.get(1), context.inputTypeAt(1)), MIN_LON, MAX_LON);
+        double lat = doubleInRange(TBigDecimal.getWrapper(input0, input0.getType()), MIN_LAT, MAX_LAT);
+        double lon = doubleInRange(TBigDecimal.getWrapper(input1, input1.getType()), MIN_LON, MAX_LON);
         Geometry geometry = factory.createPoint(new Coordinate(lat, lon));
         output.putObject(geometry);
     }

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/common/funcs/Hex.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/common/funcs/Hex.java
@@ -63,8 +63,9 @@ public class Hex
             protected void doEvaluate(TExecutionContext context,
                                       LazyList<? extends ValueSource> inputs,
                                       ValueTarget output) {
-                Charset charset = getCharset(context.inputTypeAt(0));
-                String s = inputs.get(0).getString();
+                ValueSource input = inputs.get(0);
+                Charset charset = getCharset(input.getType());
+                String s = input.getString();
                 byte[] bytes = s.getBytes(charset);
                 output.putString(Strings.hex(bytes), null);
             }

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/common/funcs/NullIf.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/common/funcs/NullIf.java
@@ -42,7 +42,10 @@ public final class NullIf extends TScalarBase
 
     @Override
     protected void doEvaluate(TExecutionContext context, LazyList<? extends ValueSource> inputs, ValueTarget output) {
-        if(TClass.compare(context.inputTypeAt(0), inputs.get(0), context.inputTypeAt(1), inputs.get(1)) == 0) {
+        ValueSource input0 = inputs.get(0);
+        ValueSource input1 = inputs.get(1);
+
+        if(TClass.compare(input0.getType(), input0, input1.getType(), input1) == 0) {
             output.putNull();
         } else {
             ValueTargets.copyFrom(inputs.get(0), output);

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/common/types/TBigDecimal.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/common/types/TBigDecimal.java
@@ -64,7 +64,7 @@ public class TBigDecimal extends TClassBase {
     public static void adjustAttrsAsNeeded(TExecutionContext context, ValueSource source,
                                            TInstance targetInstance, ValueTarget target)
     {
-        TInstance inputInstance = context.inputTypeAt(0);
+        TInstance inputInstance = source.getType();
         int inputPrecision = inputInstance.attribute(DecimalAttribute.PRECISION);
         int targetPrecision = targetInstance.attribute(DecimalAttribute.PRECISION);
         int inputScale = inputInstance.attribute(DecimalAttribute.SCALE);

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/common/types/TBinary.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/common/types/TBinary.java
@@ -180,7 +180,7 @@ public abstract class TBinary extends TClassBase {
         @Override
         public void parse(TExecutionContext context, ValueSource in, ValueTarget out) {
             String string = in.getString();
-            int charsetId = context.inputTypeAt(0).attribute(StringAttribute.CHARSET);
+            int charsetId = in.getType().attribute(StringAttribute.CHARSET);
             String charsetName = StringFactory.Charset.values()[charsetId].name();
             byte[] bytes;
             try {

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/mcompat/mcasts/Cast_From_Boolean.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/mcompat/mcasts/Cast_From_Boolean.java
@@ -159,14 +159,14 @@ public class Cast_From_Boolean {
     public static final TCast DECIMAL_TO_BOOLEAN = new TCastBase(MNumeric.DECIMAL, AkBool.INSTANCE) {
         @Override
         protected void doEvaluate(TExecutionContext context, ValueSource source, ValueTarget target) {
-            BigDecimalWrapper decimal = TBigDecimal.getWrapper(source, context.inputTypeAt(0));
+            BigDecimalWrapper decimal = TBigDecimal.getWrapper(source, source.getType());
             target.putBool(!decimal.isZero());
         }
     };
     public static final TCast DECIMAL_UNSIGNED_TO_BOOLEAN = new TCastBase(MNumeric.DECIMAL_UNSIGNED, AkBool.INSTANCE) {
         @Override
         protected void doEvaluate(TExecutionContext context, ValueSource source, ValueTarget target) {
-            BigDecimalWrapper decimal = TBigDecimal.getWrapper(source, context.inputTypeAt(0));
+            BigDecimalWrapper decimal = TBigDecimal.getWrapper(source, source.getType());
             target.putBool(!decimal.isZero());
         }
     };

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/mcompat/mcasts/Cast_From_Decimal.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/mcompat/mcasts/Cast_From_Decimal.java
@@ -48,7 +48,7 @@ public final class Cast_From_Decimal {
     public static final TCast TO_FLOAT = new TCastBase(MNumeric.DECIMAL, MApproximateNumber.FLOAT) {
         @Override
         public void doEvaluate(TExecutionContext context, ValueSource source, ValueTarget target) {
-            BigDecimalWrapper decimal = TBigDecimal.getWrapper(source, context.inputTypeAt(0));
+            BigDecimalWrapper decimal = TBigDecimal.getWrapper(source, source.getType());
             float asFloat = decimal.asBigDecimal().floatValue();
             target.putFloat(asFloat);
         }
@@ -57,7 +57,7 @@ public final class Cast_From_Decimal {
     public static final TCast TO_DOUBLE = new TCastBase(MNumeric.DECIMAL, MApproximateNumber.DOUBLE) {
         @Override
         public void doEvaluate(TExecutionContext context, ValueSource source, ValueTarget target) {
-            BigDecimalWrapper decimal = TBigDecimal.getWrapper(source, context.inputTypeAt(0));
+            BigDecimalWrapper decimal = TBigDecimal.getWrapper(source, source.getType());
             double asDouble = decimal.asBigDecimal().doubleValue();
             target.putDouble(asDouble);
         }
@@ -66,7 +66,7 @@ public final class Cast_From_Decimal {
     public static final TCast TO_BIGINT = new TCastBase(MNumeric.DECIMAL, MNumeric.BIGINT) {
         @Override
         public void doEvaluate(TExecutionContext context, ValueSource source, ValueTarget target) {
-            BigDecimalWrapper wrapped = TBigDecimal.getWrapper(source, context.inputTypeAt(0));
+            BigDecimalWrapper wrapped = TBigDecimal.getWrapper(source, source.getType());
             BigDecimal bd = wrapped.asBigDecimal();
             int signum = bd.signum();
             long longVal;

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/mcompat/mfuncs/MAbs.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/mcompat/mfuncs/MAbs.java
@@ -72,9 +72,10 @@ public class MAbs {
 
         @Override
         protected void doEvaluate(TExecutionContext context, LazyList<? extends ValueSource> inputs, ValueTarget output) {
+            ValueSource input = inputs.get(0);
             BigDecimalWrapper wrapper =
                 TBigDecimal.getWrapper(context, DEC_INDEX)
-                .set(TBigDecimal.getWrapper(inputs.get(0), context.inputTypeAt(0)));
+                .set(TBigDecimal.getWrapper(input, input.getType()));
             output.putObject(wrapper.abs());
         }
 

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/mcompat/mfuncs/MArithmetic.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/mcompat/mfuncs/MArithmetic.java
@@ -142,9 +142,11 @@ public abstract class MArithmetic extends TArithmetic {
     public static final TScalar ADD_DECIMAL = new DecimalArithmetic("plus", "+", true) {
         @Override
         protected void doEvaluate(TExecutionContext context, LazyList<? extends ValueSource> inputs, ValueTarget output) {
+            ValueSource input0 = inputs.get(0);
+            ValueSource input1 = inputs.get(1);
             output.putObject(TBigDecimal.getWrapper(context, DEC_INDEX)
-                        .set(TBigDecimal.getWrapper(inputs.get(0), context.inputTypeAt(0)))
-                        .add(TBigDecimal.getWrapper(inputs.get(1), context.inputTypeAt(1))));
+                        .set(TBigDecimal.getWrapper(input0, input0.getType()))
+                        .add(TBigDecimal.getWrapper(input1, input1.getType())));
         }
 
         @Override
@@ -226,9 +228,11 @@ public abstract class MArithmetic extends TArithmetic {
     public static final TScalar SUBTRACT_DECIMAL = new DecimalArithmetic("minus", "-", false) {
         @Override
         protected void doEvaluate(TExecutionContext context, LazyList<? extends ValueSource> inputs, ValueTarget output) {
+            ValueSource input0 = inputs.get(0);
+            ValueSource input1 = inputs.get(1);
             output.putObject(TBigDecimal.getWrapper(context, DEC_INDEX)
-                        .set(TBigDecimal.getWrapper(inputs.get(0), context.inputTypeAt(0)))
-                        .subtract(TBigDecimal.getWrapper(inputs.get(1), context.inputTypeAt(1))));
+                        .set(TBigDecimal.getWrapper(input0, input0.getType()))
+                        .subtract(TBigDecimal.getWrapper(input1, input1.getType())));
         }
 
         @Override
@@ -350,13 +354,16 @@ public abstract class MArithmetic extends TArithmetic {
         @Override
         protected void doEvaluate(TExecutionContext context, LazyList<? extends ValueSource> inputs, ValueTarget output)
         {
-            BigDecimalWrapper divisor = TBigDecimal.getWrapper(inputs.get(1), context.inputTypeAt(1));
+            ValueSource input0 = inputs.get(0);
+            ValueSource input1 = inputs.get(1);
+
+            BigDecimalWrapper divisor = TBigDecimal.getWrapper(input1, input1.getType());
 
             if (divisor.isZero()) {
                 output.putNull();
             }
             else {
-                BigDecimalWrapper numerator = TBigDecimal.getWrapper(inputs.get(0), context.inputTypeAt(0));
+                BigDecimalWrapper numerator = TBigDecimal.getWrapper(input0, input0.getType());
                 BigDecimalWrapper result = TBigDecimal.getWrapper(context, DEC_INDEX);
                 result.set(numerator);
                 result.divide(divisor, context.outputType().attribute(DecimalAttribute.SCALE));
@@ -485,9 +492,12 @@ public abstract class MArithmetic extends TArithmetic {
         @Override
         protected void doEvaluate(TExecutionContext context, LazyList<? extends ValueSource> inputs,
                                   ValueTarget output) {
+            ValueSource input0 = inputs.get(0);
+            ValueSource input1 = inputs.get(1);
+
             BigDecimalWrapper wrapper = TBigDecimal.getWrapper(context, DEC_INDEX);
-            BigDecimalWrapper numerator = TBigDecimal.getWrapper(inputs.get(0), context.inputTypeAt(0));
-            BigDecimalWrapper divisor = TBigDecimal.getWrapper(inputs.get(1), context.inputTypeAt(1));
+            BigDecimalWrapper numerator = TBigDecimal.getWrapper(input0, input0.getType());
+            BigDecimalWrapper divisor = TBigDecimal.getWrapper(input1, input1.getType());
             long rounded = wrapper.set(numerator).divide(divisor).round(0).asBigDecimal().longValue();
             output.putInt64(rounded);
         }
@@ -592,9 +602,12 @@ public abstract class MArithmetic extends TArithmetic {
         @Override
         protected void doEvaluate(TExecutionContext context, LazyList<? extends ValueSource> inputs, ValueTarget output)
         {
+            ValueSource input0 = inputs.get(0);
+            ValueSource input1 = inputs.get(1);
+
             BigDecimalWrapper wrapper = TBigDecimal.getWrapper(context, DEC_INDEX);
-            BigDecimalWrapper arg0 = TBigDecimal.getWrapper(inputs.get(0), context.inputTypeAt(0));
-            BigDecimalWrapper arg1 = TBigDecimal.getWrapper(inputs.get(1), context.inputTypeAt(1));
+            BigDecimalWrapper arg0 = TBigDecimal.getWrapper(input0, input0.getType());
+            BigDecimalWrapper arg1 = TBigDecimal.getWrapper(input1, input1.getType());
             
             output.putObject(wrapper.set(arg0).multiply(arg1));
         }
@@ -709,14 +722,17 @@ public abstract class MArithmetic extends TArithmetic {
 
         @Override
         protected void doEvaluate(TExecutionContext context, LazyList<? extends ValueSource> inputs, ValueTarget output)
-        {            
-             BigDecimalWrapper divisor = TBigDecimal.getWrapper(inputs.get(1), context.inputTypeAt(1));
+        {
+            ValueSource input0 = inputs.get(0);
+            ValueSource input1 = inputs.get(1);
+
+             BigDecimalWrapper divisor = TBigDecimal.getWrapper(input1, input1.getType());
 
              if (divisor.isZero())
                  output.putNull();
              else
                  output.putObject(TBigDecimal.getWrapper(context, DEC_INDEX)
-                                     .set(TBigDecimal.getWrapper(inputs.get(0), context.inputTypeAt(0)))
+                                     .set(TBigDecimal.getWrapper(input0, input0.getType()))
                                      .mod(divisor));
         }
     };

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/mcompat/mfuncs/MAscii.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/mcompat/mfuncs/MAscii.java
@@ -70,7 +70,7 @@ public class MAscii extends TScalarBase
             output.putInt32(0);
         }
         else {
-            String charset = StringFactory.Charset.of(context.inputTypeAt(0).attribute(StringAttribute.CHARSET));
+            String charset = StringFactory.Charset.of(sval.getType().attribute(StringAttribute.CHARSET));
             try {
                 byte[] bytes = str.substring(0, 1).getBytes(charset);
                 output.putInt32(bytes[0] & 0xFF);

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/mcompat/mfuncs/MDateAddSub.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/mcompat/mfuncs/MDateAddSub.java
@@ -176,7 +176,7 @@ public class MDateAddSub extends TScalarBase
                     dt = MDateAndTime.toJodaDateTime(ymd, "UTC");
                     helper.compute(dt, millis);
                     
-                    if (FirstType.DATE.adjustFirstArg(context.inputTypeAt(1)) == FirstType.DATE)
+                    if (FirstType.DATE.adjustFirstArg(inputs.get(1).getType()) == FirstType.DATE)
                         output.putString(dt.toString("YYYY-MM-dd"), null);
                     else
                         output.putString(dt.toString("YYYY-MM-dd HH:mm:ss"), null);
@@ -524,7 +524,7 @@ public class MDateAddSub extends TScalarBase
         {
             MutableDateTime dt = MDateAndTime.toJodaDateTime(ymd, "UTC");    // calculations should be done
             helper.compute(dt, secondArg.toMillis(inputs.get(pos1)));      // in UTC (to avoid daylight-saving side effects)
-            firstArg.adjustFirstArg(context.inputTypeAt(pos1)).putResult(output, dt, context);
+            firstArg.adjustFirstArg(inputs.get(pos1).getType()).putResult(output, dt, context);
         }
     }
 

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/mcompat/mfuncs/MField.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/mcompat/mfuncs/MField.java
@@ -70,11 +70,11 @@ public final class MField extends TScalarBase {
         ValueSource needle = inputs.get(0);
         int result = 0;
         if (!needle.isNull()) {
-            TInstance needleInstance = context.inputTypeAt(0);
+            TInstance needleInstance = needle.getType();
             for (int i = 1, size = inputs.size(); i < size; ++i) {
                 ValueSource arg = inputs.get(i);
                 if (!arg.isNull()) {
-                    TInstance argInstance = context.inputTypeAt(i);
+                    TInstance argInstance = arg.getType();
                     int cmp = TClass.compare(needleInstance, needle, argInstance, arg);
                     if (cmp == 0) {
                         result = i;

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/mcompat/mfuncs/MLength.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/mcompat/mfuncs/MLength.java
@@ -73,11 +73,12 @@ public abstract class MLength extends TScalarBase
         @Override
         protected void doEvaluate(TExecutionContext context, LazyList<? extends ValueSource> inputs, ValueTarget output)
         {
-            int charsetId = context.inputTypeAt(0).attribute(StringAttribute.CHARSET);
+            ValueSource input = inputs.get(0);
+            int charsetId = input.getType().attribute(StringAttribute.CHARSET);
             String charset = (StringFactory.Charset.values())[charsetId].name();
             try
             {
-                int length = (inputs.get(0).getString()).getBytes(charset).length;
+                int length = (input.getString()).getBytes(charset).length;
                 length *= multiplier;
                 output.putInt32(length);
             }

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/mcompat/mfuncs/MRoundBase.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/mcompat/mfuncs/MRoundBase.java
@@ -70,7 +70,8 @@ public abstract class MRoundBase extends TScalarBase {
             protected void doEvaluate(TExecutionContext context, LazyList<? extends ValueSource> inputs, ValueTarget output) {
                 TClass cached = (TClass) context.objectAt(RET_TYPE_INDEX);
                 BigDecimalWrapper result = TBigDecimal.getWrapper(context, DEC_INDEX);
-                result.set(TBigDecimal.getWrapper(inputs.get(0), context.inputTypeAt(0)));
+                ValueSource input = inputs.get(0);
+                result.set(TBigDecimal.getWrapper(input, input.getType()));
                 result = roundType.evaluate(result);
                 
                 TClass outT = context.outputType().typeClass();

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/mcompat/mfuncs/MRoundTruncateDecimal.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/mcompat/mfuncs/MRoundTruncateDecimal.java
@@ -57,7 +57,8 @@ public class MRoundTruncateDecimal extends TScalarBase {
     @Override
     protected void doEvaluate(TExecutionContext context, LazyList<? extends ValueSource> inputs, ValueTarget output) {
         BigDecimalWrapper result = TBigDecimal.getWrapper(context, DEC_INDEX);
-        result.set(TBigDecimal.getWrapper(inputs.get(0), context.inputTypeAt(0)));
+        ValueSource input = inputs.get(0);
+        result.set(TBigDecimal.getWrapper(input, input.getType()));
         int scale = signatureStrategy.roundToScale(inputs);
         roundingStrategy.apply(result, scale);
         output.putObject(result);

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/mcompat/mfuncs/MSign.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/mcompat/mfuncs/MSign.java
@@ -41,7 +41,8 @@ public class MSign extends TScalarBase {
 
     @Override
     protected void doEvaluate(TExecutionContext context, LazyList<? extends ValueSource> inputs, ValueTarget output) {
-        BigDecimalWrapper num = TBigDecimal.getWrapper(inputs.get(0), context.inputTypeAt(0));
+        ValueSource input = inputs.get(0);
+        BigDecimalWrapper num = TBigDecimal.getWrapper(input, input.getType());
         
         output.putInt64(num.getSign());      
     }

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/mcompat/mfuncs/MUnaryMinus.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/mcompat/mfuncs/MUnaryMinus.java
@@ -115,7 +115,7 @@ public final class MUnaryMinus extends TScalarBase {
             @Override
             protected void apply(ValueSource in, ValueTarget out, TExecutionContext context) {
                 BigDecimalWrapper wrapped = TBigDecimal.getWrapper(context, DEC_INDEX);
-                wrapped.set(TBigDecimal.getWrapper(in, context.inputTypeAt(0)));
+                wrapped.set(TBigDecimal.getWrapper(in, in.getType()));
                 wrapped.negate();
                 out.putObject(wrapped);
             }

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/service/TCastsRegistry.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/service/TCastsRegistry.java
@@ -313,7 +313,7 @@ public final class TCastsRegistry {
                 target.putNull();
                 return;
             }
-            TInstance srcInst = context.inputTypeAt(0);
+            TInstance srcInst = source.getType();
             TInstance dstInst = context.outputType();
             tClass.selfCast(context, srcInst, source,  dstInst, target);
         }
@@ -382,7 +382,7 @@ public final class TCastsRegistry {
             }
             // TODO cache
             TExecutionContext firstContext = context.deriveContext(
-                    Collections.singletonList(context.inputTypeAt(0)),
+                    Collections.singletonList(source.getType()),
                     intermediateType
             );
             TExecutionContext secondContext = context.deriveContext(

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/texpressions/TInExpression.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/texpressions/TInExpression.java
@@ -89,11 +89,11 @@ public final class TInExpression {
 
         @Override
         protected void doEvaluate(TExecutionContext context, LazyList<? extends ValueSource> inputs, ValueTarget output) {
-            TInstance lhsInstance = context.inputTypeAt(0);
             ValueSource lhsSource = inputs.get(0);
+            TInstance lhsInstance = lhsSource.getType();
             for (int i=1, nInputs = inputs.size(); i < nInputs; ++i) {
-                TInstance rhsInstance = context.inputTypeAt(i);
                 ValueSource rhsSource = inputs.get(i);
+                TInstance rhsInstance = rhsSource.getType();
                 if (0 == doCompare(lhsInstance, lhsSource, rhsInstance, rhsSource)) {
                     output.putBool(true);
                     return;

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/texpressions/TScalarBase.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/texpressions/TScalarBase.java
@@ -143,6 +143,12 @@ public abstract class TScalarBase implements TScalar {
             public ValueSource get(int i) {
                 TPreptimeValue ptValue = inputs.get(i);
                 ValueSource source = ptValue.value();
+                if (source == null) {
+                    source = ValueSources.getNullSource(ptValue.type());
+                }
+                else if (source.getType().typeClass() instanceof TString) {
+                    source = ValueSources.valuefromObject(source.getObject(), ptValue.type());
+                }
                 assert allowNonConstsInEvaluation() || source != null
                         : "non-constant value where constant value expected";
                 return source;


### PR DESCRIPTION
TScalarBase had to change to a little, but the input types should be correct now and inputTypeAt shouldn't be necessary.