### PR TITLE
Convert Postgres-compatible statement_timeout to queryTimeoutMillis.

### DIFF
--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/sql/server/ServerSessionBase.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/sql/server/ServerSessionBase.java
@@ -140,6 +140,13 @@ public abstract class ServerSessionBase extends AISBinderContext implements Serv
                 queryTimeoutMilli = (long)(Double.parseDouble(value) * 1000);
             return true;
         }
+        if ("statement_timeout".equals(key)) {
+            if (value == null)
+                queryTimeoutMilli = null;
+            else
+                queryTimeoutMilli = Long.parseLong(value);
+            return true;
+        }
         if ("transactionPeriodicallyCommit".equals(key)) {
             transactionPeriodicallyCommit = ServerTransaction.PeriodicallyCommit.fromProperty(value);
             return true;

--- a/fdb-sql-layer-pg/src/main/java/com/foundationdb/sql/pg/PostgresSessionStatement.java
+++ b/fdb-sql-layer-pg/src/main/java/com/foundationdb/sql/pg/PostgresSessionStatement.java
@@ -70,6 +70,8 @@ public class PostgresSessionStatement implements PostgresStatement
         "optimizerDummySetting",
         // Execution.
         "constraintCheckTime", "queryTimeoutSec", "transactionPeriodicallyCommit",
+        // Compatible and translated.
+        "statement_timeout",
         // Compatible that actually does something.
         "client_encoding",
         // Compatible but ignored.


### PR DESCRIPTION
I appreciate that such support is a slippery-slope. But there is no way to keep recent Npgsql from sending this and the translation is straightforward.