### PR TITLE
Fix TClass#doCompare integer handling

### DIFF
--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/TClass.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/TClass.java
@@ -24,10 +24,6 @@ import com.foundationdb.server.types.texpressions.SerializeAs;
 import com.foundationdb.sql.types.DataTypeDescriptor;
 import com.foundationdb.util.AkibanAppender;
 import com.foundationdb.util.ArgumentValidation;
-import com.google.common.primitives.Booleans;
-import com.google.common.primitives.Doubles;
-import com.google.common.primitives.Floats;
-import com.google.common.primitives.Longs;
 import com.google.common.primitives.UnsignedBytes;
 
 import java.lang.reflect.Field;
@@ -81,10 +77,20 @@ public abstract class TClass {
         return (compare(sourceA, sourceB) == 0);
     }
 
+    /**
+     * Compares two (potentially {@code null}) values with {@link ValueSource#getType()} as their types.
+     * @return The value {@code 0} if {@code sourceA == sourceB};
+     *         a value less than {@code 0} if {@code sourceA < sourceB}; and
+     *         a value greater than {@code 0} if {@code sourceA > sourceB}
+     */
     public static int compare(ValueSource sourceA, ValueSource sourceB) {
         return compare(sourceA.getType(), sourceA, sourceB.getType(), sourceB);
     }
 
+    /**
+     * Compare {@code sourceA} and {@code sourceB} as {@code typeA} and {@code typeB}.
+     * @return See {@link #compare(ValueSource,ValueSource)}
+     */
     public static int compare(TInstance typeA, ValueSource sourceA, TInstance typeB, ValueSource sourceB) {
         if (comparisonNeedsCasting(typeA, typeB))
             throw new IllegalArgumentException("can't compare " + typeA + " and " + typeB);
@@ -97,14 +103,8 @@ public abstract class TClass {
     }
 
     /**
-     * Compares two values, assuming neither is null. The call site (<tt>TClass.compare</tt>) will handle the case
-     * that either or both sources is null.
-     * @param typeA the first operand's instance
-     * @param sourceA the first operand's value, which will not represent a null ValueSource
-     * @param typeB the second operand's instance
-     * @param sourceB the second operand's value, which will not represent a null ValueSource
-     * @return -1 if sourceA is less than sourceB; 0 if they're equal; 1 if sourceA is greater than sourceB
-     * @see TClass#compare(TInstance, com.foundationdb.server.types.value.ValueSource, TInstance, com.foundationdb.server.types.value.ValueSource)
+     * As {@link #compare(TInstance,ValueSource,TInstance,ValueSource)} with
+     * {@code null} expected to be handled already.
      */
     protected int doCompare(TInstance typeA, ValueSource sourceA, TInstance typeB, ValueSource sourceB) {
         if (sourceA.hasCacheValue() && sourceB.hasCacheValue()) {
@@ -116,23 +116,23 @@ public abstract class TClass {
                 return comparableA.compareTo(sourceB.getObject());
             }
         }
-        switch (TInstance.underlyingType(sourceA.getType())) {
+        switch (TInstance.underlyingType(typeA)) {
         case BOOL:
-            return Booleans.compare(sourceA.getBoolean(), sourceB.getBoolean());
+            return Boolean.compare(sourceA.getBoolean(), sourceB.getBoolean());
         case INT_8:
-            return sourceA.getInt8() - sourceB.getInt8();
+            return Integer.compare(sourceA.getInt8(), sourceB.getInt8());
         case INT_16:
-            return sourceA.getInt16() - sourceB.getInt16();
+            return Integer.compare(sourceA.getInt16(), sourceB.getInt16());
         case UINT_16:
-            return sourceA.getUInt16() - sourceB.getUInt16();
+            return Integer.compare(sourceA.getUInt16(), sourceB.getUInt16());
         case INT_32:
-            return sourceA.getInt32() - sourceB.getInt32();
+            return Integer.compare(sourceA.getInt32(), sourceB.getInt32());
         case INT_64:
-            return Longs.compare(sourceA.getInt64(), sourceB.getInt64());
+            return Long.compare(sourceA.getInt64(), sourceB.getInt64());
         case FLOAT:
-            return Floats.compare(sourceA.getFloat(), sourceB.getFloat());
+            return Float.compare(sourceA.getFloat(), sourceB.getFloat());
         case DOUBLE:
-            return Doubles.compare(sourceA.getDouble(), sourceB.getDouble());
+            return Double.compare(sourceA.getDouble(), sourceB.getDouble());
         case BYTES:
             return UnsignedBytes.lexicographicalComparator().compare(sourceA.getBytes(), sourceB.getBytes());
         case STRING:

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/mcompat/mtypes/MNumeric.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/mcompat/mtypes/MNumeric.java
@@ -213,6 +213,11 @@ public class MNumeric extends SimpleDtdTClass {
         protected ValueIO getValueIO() {
             return bigintUnsignedIO;
         }
+
+        @Override
+        protected int doCompare(TInstance typeA, ValueSource sourceA, TInstance typeB, ValueSource sourceB) {
+            return UnsignedLongs.compare(sourceA.getInt64(), sourceB.getInt64());
+        }
     };
 
     public static final TClass DECIMAL_UNSIGNED = new MBigDecimal("decimal unsigned", 10)

--- a/fdb-sql-layer-core/src/test/java/com/foundationdb/server/types/AkTypesComparisonTest.java
+++ b/fdb-sql-layer-core/src/test/java/com/foundationdb/server/types/AkTypesComparisonTest.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (C) 2009-2015 FoundationDB, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.foundationdb.server.types;
+
+import com.foundationdb.junit.SelectedParameterizedRunner;
+import com.foundationdb.server.types.aksql.AkBundle;
+import com.foundationdb.server.types.aksql.aktypes.AkBool;
+import com.foundationdb.server.types.aksql.aktypes.AkGUID;
+import com.foundationdb.server.types.aksql.aktypes.AkGeometry;
+import com.foundationdb.server.types.aksql.aktypes.AkInterval;
+import com.foundationdb.server.types.aksql.aktypes.AkResultSet;
+import com.foundationdb.server.types.value.Value;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+@RunWith(SelectedParameterizedRunner.class)
+public class AkTypesComparisonTest extends TypeComparisonTestBase
+{
+    @Parameters(name="{0}")
+    public static Collection<Object[]> types() throws Exception {
+        return makeParams(
+            AkBundle.INSTANCE.id(),
+            Arrays.asList(
+                typeInfo(AkBool.INSTANCE, false, true),
+                typeInfo(AkInterval.MONTHS, Long.MIN_VALUE, 0L, Long.MAX_VALUE),
+                typeInfo(AkInterval.SECONDS, Long.MIN_VALUE, 0L, Long.MAX_VALUE)
+            ),
+            Arrays.asList(
+                AkGeometry.INSTANCE,
+                AkGUID.INSTANCE,
+                AkResultSet.INSTANCE
+            )
+        );
+    }
+
+    public AkTypesComparisonTest(String name, Value a, Value b, int expected) throws Exception {
+        super(name, a, b, expected);
+    }
+}

--- a/fdb-sql-layer-core/src/test/java/com/foundationdb/server/types/MTypesComparisonTest.java
+++ b/fdb-sql-layer-core/src/test/java/com/foundationdb/server/types/MTypesComparisonTest.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright (C) 2009-2015 FoundationDB, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.foundationdb.server.types;
+
+import com.foundationdb.junit.SelectedParameterizedRunner;
+import com.foundationdb.server.types.mcompat.MBundle;
+import com.foundationdb.server.types.mcompat.mtypes.MApproximateNumber;
+import com.foundationdb.server.types.mcompat.mtypes.MBinary;
+import com.foundationdb.server.types.mcompat.mtypes.MDateAndTime;
+import com.foundationdb.server.types.mcompat.mtypes.MNumeric;
+import com.foundationdb.server.types.mcompat.mtypes.MString;
+import com.foundationdb.server.types.value.Value;
+import com.google.common.primitives.UnsignedLongs;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Collection;
+
+@RunWith(SelectedParameterizedRunner.class)
+public class MTypesComparisonTest extends TypeComparisonTestBase
+{
+    @Parameters(name="{0}")
+    public static Collection<Object[]> types() throws Exception {
+        return makeParams(
+            MBundle.INSTANCE.id(),
+            Arrays.asList(
+                typeInfo(MApproximateNumber.FLOAT, -Float.MAX_VALUE, 0f, Float.MAX_VALUE),
+                typeInfo(MApproximateNumber.FLOAT_UNSIGNED, 0f, Float.MAX_VALUE),
+                typeInfo(MApproximateNumber.DOUBLE, -Double.MAX_VALUE, 0d, Double.MAX_VALUE),
+                typeInfo(MApproximateNumber.DOUBLE_UNSIGNED, 0d, Double.MAX_VALUE),
+
+                typeInfo(MNumeric.TINYINT, -128, 0, 127),
+                typeInfo(MNumeric.TINYINT_UNSIGNED, 0, 255),
+                typeInfo(MNumeric.SMALLINT, -32768, 0, 32767),
+                typeInfo(MNumeric.SMALLINT_UNSIGNED, 0, 65535),
+                typeInfo(MNumeric.MEDIUMINT, -8388608, 0, 8388607),
+                typeInfo(MNumeric.MEDIUMINT_UNSIGNED, 0, 16777216),
+                typeInfo(MNumeric.INT, Integer.MIN_VALUE, 0, Integer.MAX_VALUE),
+                typeInfo(MNumeric.INT_UNSIGNED, 0L, 1L << 32),
+                typeInfo(MNumeric.BIGINT, Long.MIN_VALUE, 0, Long.MAX_VALUE),
+                typeInfo(MNumeric.BIGINT_UNSIGNED, 0L, UnsignedLongs.MAX_VALUE),
+
+                // Decimal default is (10,0)
+                typeInfo(MNumeric.DECIMAL,
+                         new BigDecimal("-9999999999"),
+                         new BigDecimal("0000000000"),
+                         new BigDecimal("9999999999")),
+                typeInfo(MNumeric.DECIMAL_UNSIGNED,
+                         new BigDecimal("0000000000"),
+                         new BigDecimal("9999999999")),
+
+                typeInfo(MDateAndTime.DATE,
+                         MDateAndTime.encodeDate(0, 0, 0),
+                         MDateAndTime.encodeDate(9999, 12, 31)),
+                typeInfo(MDateAndTime.DATETIME,
+                         MDateAndTime.encodeDateTime(1000, 1, 1, 0, 0, 0),
+                         MDateAndTime.encodeDateTime(9999, 12, 31, 23, 59, 59)),
+                typeInfo(MDateAndTime.TIME,
+                         MDateAndTime.encodeTime(-838, 59, 59, null),
+                         MDateAndTime.encodeTime(838, 59, 59, null)),
+                typeInfo(MDateAndTime.TIMESTAMP, 0, Integer.MAX_VALUE),
+                typeInfo(MDateAndTime.YEAR, 0, 255),
+
+                // Just one of the binary types
+                typeInfo(MBinary.BINARY, new byte[] { (byte)0x00 }, new byte[] { (byte)0xFF })
+            ),
+            Arrays.asList(
+                MBinary.VARBINARY,
+                MBinary.TINYBLOB,
+                MBinary.BLOB,
+                MBinary.MEDIUMBLOB,
+                MBinary.LONGBLOB,
+                MString.CHAR,
+                MString.VARCHAR,
+                MString.TINYTEXT,
+                MString.TEXT,
+                MString.MEDIUMTEXT,
+                MString.LONGTEXT
+            )
+        );
+    }
+
+    public MTypesComparisonTest(String name, Value a, Value b, int expected) throws Exception {
+        super(name, a, b, expected);
+    }
+}

--- a/fdb-sql-layer-core/src/test/java/com/foundationdb/server/types/TypeComparisonTestBase.java
+++ b/fdb-sql-layer-core/src/test/java/com/foundationdb/server/types/TypeComparisonTestBase.java
@@ -74,8 +74,14 @@ public abstract class TypeComparisonTestBase
         List<Object[]> params = new ArrayList<>();
         for(TypeInfo info : typeInfos) {
             String name = info.type.name().unqualifiedName();
+            Value vnull = ValueSources.valuefromObject(null, info.type.instance(true));
             Value min = ValueSources.valuefromObject(info.min, info.type.instance(true));
             Value max = ValueSources.valuefromObject(info.max, info.type.instance(true));
+            params.add(new Object[] { name + "_null_null", vnull, vnull, 0 });
+            params.add(new Object[] { name + "_null_min", vnull, min, -1 });
+            params.add(new Object[] { name + "_min_null", min, vnull, 1 });
+            params.add(new Object[] { name + "_null_max", vnull, max, -1 });
+            params.add(new Object[] { name + "_max_null", max, vnull, 1 });
             params.add(new Object[] { name + "_min_min", min, min, 0 });
             params.add(new Object[] { name + "_min_max", min, max, -1 });
             params.add(new Object[] { name + "_max_min", max, min, 1 });

--- a/fdb-sql-layer-core/src/test/java/com/foundationdb/server/types/TypeComparisonTestBase.java
+++ b/fdb-sql-layer-core/src/test/java/com/foundationdb/server/types/TypeComparisonTestBase.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright (C) 2009-2015 FoundationDB, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.foundationdb.server.types;
+
+import com.foundationdb.server.types.service.ReflectiveInstanceFinder;
+import com.foundationdb.server.types.value.Value;
+import com.foundationdb.server.types.value.ValueSources;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThan;
+import static org.junit.Assert.assertThat;
+
+public abstract class TypeComparisonTestBase
+{
+    protected static class TypeInfo {
+        public final TClass type;
+        public final Object min;
+        public final Object zero;
+        public final Object max;
+
+        public TypeInfo(TClass type, Object min, Object zero, Object max) {
+            this.type = type;
+            this.min = min;
+            this.zero = zero;
+            this.max = max;
+        }
+    }
+
+    protected static TypeInfo typeInfo(TClass type, Object min, Object max) {
+        return typeInfo(type, min, null, max);
+    }
+
+    protected static TypeInfo typeInfo(TClass type, Object min, Object zero, Object max) {
+        return new TypeInfo(type, min, zero, max);
+    }
+
+    public static Collection<Object[]> makeParams(TBundleID bundle, Collection<TypeInfo> typeInfos, Collection<TClass> ignore) throws Exception {
+        ReflectiveInstanceFinder finder = new ReflectiveInstanceFinder();
+        for(TClass type : finder.find(TClass.class)) {
+            if((type.name().bundleId() == bundle) && !ignore.contains(type)) {
+                boolean found = false;
+                for(TypeInfo info : typeInfos) {
+                    if(info.type == type) {
+                        found = true;
+                        break;
+                    }
+                }
+                if(!found) {
+                    throw new AssertionError("No TypeInfo for " + type.name());
+                }
+            }
+        }
+        List<Object[]> params = new ArrayList<>();
+        for(TypeInfo info : typeInfos) {
+            String name = info.type.name().unqualifiedName();
+            Value min = ValueSources.valuefromObject(info.min, info.type.instance(true));
+            Value max = ValueSources.valuefromObject(info.max, info.type.instance(true));
+            params.add(new Object[] { name + "_min_min", min, min, 0 });
+            params.add(new Object[] { name + "_min_max", min, max, -1 });
+            params.add(new Object[] { name + "_max_min", max, min, 1 });
+            params.add(new Object[] { name + "_max_max", max, max, 0 });
+            if(info.zero != null) {
+                Value zero = ValueSources.valuefromObject(info.zero, info.type.instance(true));
+                params.add(new Object[] { name + "_min_zero", min, zero, -1 });
+                params.add(new Object[] { name + "_zero_min", zero, min, 1 });
+                params.add(new Object[] { name + "_zero_zero", zero, zero, 0 });
+                params.add(new Object[] { name + "_zero_max", zero, max, -1 });
+                params.add(new Object[] { name + "_max_zero", max, zero, 1 });
+            }
+        }
+        return params;
+    }
+
+
+    private final String name;
+    private final Value a;
+    private final Value b;
+    private final int expected;
+
+    public TypeComparisonTestBase(String name, Value a, Value b, int expected) throws Exception {
+        this.name = name;
+        this.a = a;
+        this.b = b;
+        this.expected = expected;
+    }
+
+
+    @Test
+    public void testCompare() {
+        String desc = String.format("%s compareTo %s ", a, b);
+        int actual = TClass.compare(a,b);
+        if(expected == 0) {
+            assertThat(desc, actual, equalTo(0));
+        } else if(expected < 0) {
+            assertThat(desc, actual, lessThan(0));
+        } else {
+            assertThat(desc, actual, greaterThan(0));
+        }
+    }
+}


### PR DESCRIPTION
For integer, use stock compare() as subtraction can wrap around and give the wrong answer. Override and use proper method for `bigint unsigned` as well.