### PR TITLE
Reject indexes on BOOLEAN by default

### DIFF
--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/error/NotAllowedByConfigException.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/error/NotAllowedByConfigException.java
@@ -17,7 +17,8 @@
 
 package com.foundationdb.server.error;
 
-public class NotAllowedByConfigException extends InvalidOperationException
+// Not strictly limited to Startup but can occur there.
+public class NotAllowedByConfigException extends StartupFailureException
 {
     public NotAllowedByConfigException(String desc) {
         super(ErrorCode.NOT_ALLOWED_BY_CONFIG, desc);

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/error/StartupFailureException.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/error/StartupFailureException.java
@@ -16,13 +16,8 @@
  */
 package com.foundationdb.server.error;
 
-public class StartupFailureException extends InvalidOperationException {
-
-    protected StartupFailureException(ErrorCode code, Long i, Long j, Long k,
-            Long l) {
-        super(code, i, j, k, l);
-    }
-
+public class StartupFailureException extends InvalidOperationException
+{
     protected StartupFailureException(ErrorCode code, Object... args) {
         super(code, args);
     }

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/FDBSchemaManager.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/FDBSchemaManager.java
@@ -240,6 +240,10 @@ public class FDBSchemaManager extends AbstractSchemaManager implements Service, 
             });
         }
 
+        for(Table t : curAIS.getTables().values()) {
+            checkAllowedIndexes(t.getIndexesIncludingInternal());
+        }
+
         listenerService.registerTableListener(this);
 
         registerSystemTables();

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/SchemaManager.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/SchemaManager.java
@@ -264,4 +264,7 @@ public interface SchemaManager {
 
     /** An <code>AISCloner</code> for merging. */
     AISCloner getAISCloner();
+
+    /** Throw an error if there are unsupported indexes. */
+    void checkAllowedIndexes(Collection<? extends Index> indexes);
 }

--- a/fdb-sql-layer-core/src/main/resources/com/foundationdb/server/service/config/configuration-defaults.properties
+++ b/fdb-sql-layer-core/src/main/resources/com/foundationdb/server/service/config/configuration-defaults.properties
@@ -21,6 +21,8 @@ fdbsql.tmp_dir=/tmp
 fdbsql.feature.ddl_with_dml_on=false
 # Cannot CREATE spatial if false
 fdbsql.feature.spatial_index_on=false
+# Cannot CREATE index on boolean if false
+fdbsql.feature.boolean_index_on=false
 # Number of groups in a query triggering the FK join optimizer
 fdbsql.optimizer.fk_join_threshold=8
 

--- a/fdb-sql-layer-core/src/test/java/com/foundationdb/server/service/config/TestConfigService.java
+++ b/fdb-sql-layer-core/src/test/java/com/foundationdb/server/service/config/TestConfigService.java
@@ -64,7 +64,7 @@ public class TestConfigService extends ConfigurationServiceImpl {
         ret.put(BUCKET_COUNT_KEY, BUCKET_COUNT);
         ret.put(FEATURE_DDL_WITH_DML_KEY, "true");
         ret.put(FEATURE_SPATIAL_INDEX_KEY, "true");
-        ret.put(FEATURE_DIRECT_ROUTINES_KEY, "true");
+        ret.put(FEATURE_BOOLEAN_INDEX_KEY, "true");
         // extra = test overrides
         if (extraProperties != null) {
             for (final Map.Entry<String, String> property : extraProperties.entrySet()) {
@@ -144,5 +144,5 @@ public class TestConfigService extends ConfigurationServiceImpl {
 
     public final static String FEATURE_DDL_WITH_DML_KEY = "fdbsql.feature.ddl_with_dml_on";
     public final static String FEATURE_SPATIAL_INDEX_KEY = "fdbsql.feature.spatial_index_on";
-    public final static String FEATURE_DIRECT_ROUTINES_KEY = "fdbsql.feature.direct_routines_on";
+    public final static String FEATURE_BOOLEAN_INDEX_KEY = "fdbsql.feature.spatial_index_on";
 }

--- a/fdb-sql-layer-core/src/test/java/com/foundationdb/server/service/is/BasicInfoSchemaTablesServiceImplTest.java
+++ b/fdb-sql-layer-core/src/test/java/com/foundationdb/server/service/is/BasicInfoSchemaTablesServiceImplTest.java
@@ -822,6 +822,11 @@ public class BasicInfoSchemaTablesServiceImplTest {
         }
 
         @Override
+        public void checkAllowedIndexes(Collection<? extends Index> indexes) {
+            // None
+        }
+
+        @Override
         public TableName registerStoredInformationSchemaTable(Table newTable, int version) {
             throw new UnsupportedOperationException();
         }


### PR DESCRIPTION
Due to Tuple ordering issue, as discussed.

Handled as a "feature" config option so anyone affected can at least be walked through recovery.