### PR TITLE
Switch to new true code; give error for former one

### DIFF
--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/AbstractSchemaManager.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/AbstractSchemaManager.java
@@ -102,7 +102,6 @@ public abstract class AbstractSchemaManager implements Service, SchemaManager {
 
     public static final String SKIP_AIS_UPGRADE_PROPERTY = "fdbsql.skip_ais_upgrade";
     public static final String FEATURE_SPATIAL_INDEX_PROPERTY = "fdbsql.feature.spatial_index_on";
-    public static final String FEATURE_BOOLEAN_INDEX_PROPERTY = "fdbsql.feature.boolean_index_on";
 
     public static final String COLLATION_MODE = "fdbsql.collation_mode";
     public static final String DEFAULT_CHARSET = "fdbsql.default_charset";
@@ -119,7 +118,6 @@ public abstract class AbstractSchemaManager implements Service, SchemaManager {
     protected TypesTranslator typesTranslator;
     protected AISCloner aisCloner;
     protected boolean withSpatialIndexes;
-    protected boolean withBooleanIndexes;
 
     protected SecurityService securityService;
 
@@ -243,7 +241,6 @@ public abstract class AbstractSchemaManager implements Service, SchemaManager {
                                        storageFormatRegistry);
         storageFormatRegistry.registerStandardFormats();
         this.withSpatialIndexes = Boolean.parseBoolean(config.getProperty(FEATURE_SPATIAL_INDEX_PROPERTY));
-        this.withBooleanIndexes = Boolean.parseBoolean(config.getProperty(FEATURE_BOOLEAN_INDEX_PROPERTY));
     }
 
     @Override
@@ -808,15 +805,6 @@ public abstract class AbstractSchemaManager implements Service, SchemaManager {
             for(Index index : indexes) {
                 if(index.isSpatial()) {
                     throw new NotAllowedByConfigException("spatial index: " + index.getIndexName());
-                }
-            }
-        }
-        if(!withBooleanIndexes) {
-            for(Index index : indexes) {
-                for(IndexColumn icol : index.getKeyColumns()) {
-                    if(icol.getColumn().getType().typeClass().jdbcType() == Types.BOOLEAN) {
-                        throw new NotAllowedByConfigException("boolean index column: " + index.getIndexName() + "." + icol.getColumn().getName());
-                    }
                 }
             }
         }

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/FDBSchemaManager.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/FDBSchemaManager.java
@@ -137,15 +137,16 @@ public class FDBSchemaManager extends AbstractSchemaManager implements Service, 
      * 4) Unique index format change
      * 5) Remove group index row counts
      * 6) Metadata stored using blob layer
+     * 7) Tuple encoding for boolean true
      */
-    private static final long CURRENT_DATA_VERSION = 6;
+    private static final long CURRENT_DATA_VERSION = 7;
     /**
      * 1) Initial directory based
      * 2) Online metadata support
      * 3) Type bundles
      * 4) Online DDL error-ing
-     * 5) ????
-     * 6) ????
+     * 5) index constraint naming
+     * 6) remove index fk constraints
      * 7) Hidden PK to Sequence/__row_id
      */
     private static final long CURRENT_META_VERSION = 7;

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/tuple/TupleFloatingUtil.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/tuple/TupleFloatingUtil.java
@@ -51,8 +51,9 @@ class TupleFloatingUtil {
     static final byte BIGINT_POS_CODE = 0x1d;
     static final byte BIGDEC_NEG_CODE = 0x23;
     static final byte BIGDEC_POS_CODE = 0x24;
-    static final byte TRUE_CODE = 0x25;
+    static final byte DEPRECATED_TRUE_CODE = 0x25;
     static final byte FALSE_CODE = 0x26;
+    static final byte TRUE_CODE = 0x27;
     static final byte UUID_CODE = 0x30;
 
     static byte[] floatingPointToByteArray (float value) {
@@ -291,6 +292,9 @@ class TupleFloatingUtil {
         }
         if (code == BIGINT_POS_CODE || code == BIGINT_NEG_CODE) {
             return decodeBigInt(rep, start);
+        }
+        if (code == DEPRECATED_TRUE_CODE) {
+            throw new IllegalArgumentException("Deprecated tuple data type " + code + " at index " + pos);
         }
         throw new IllegalArgumentException("Unknown tuple data type " + code + " at index " + pos);
     }

--- a/fdb-sql-layer-core/src/main/resources/com/foundationdb/server/service/config/configuration-defaults.properties
+++ b/fdb-sql-layer-core/src/main/resources/com/foundationdb/server/service/config/configuration-defaults.properties
@@ -21,8 +21,6 @@ fdbsql.tmp_dir=/tmp
 fdbsql.feature.ddl_with_dml_on=false
 # Cannot CREATE spatial if false
 fdbsql.feature.spatial_index_on=false
-# Cannot CREATE index on boolean if false
-fdbsql.feature.boolean_index_on=false
 # Number of groups in a query triggering the FK join optimizer
 fdbsql.optimizer.fk_join_threshold=8
 

--- a/fdb-sql-layer-core/src/test/java/com/foundationdb/server/service/config/TestConfigService.java
+++ b/fdb-sql-layer-core/src/test/java/com/foundationdb/server/service/config/TestConfigService.java
@@ -64,7 +64,6 @@ public class TestConfigService extends ConfigurationServiceImpl {
         ret.put(BUCKET_COUNT_KEY, BUCKET_COUNT);
         ret.put(FEATURE_DDL_WITH_DML_KEY, "true");
         ret.put(FEATURE_SPATIAL_INDEX_KEY, "true");
-        ret.put(FEATURE_BOOLEAN_INDEX_KEY, "true");
         // extra = test overrides
         if (extraProperties != null) {
             for (final Map.Entry<String, String> property : extraProperties.entrySet()) {
@@ -144,5 +143,4 @@ public class TestConfigService extends ConfigurationServiceImpl {
 
     public final static String FEATURE_DDL_WITH_DML_KEY = "fdbsql.feature.ddl_with_dml_on";
     public final static String FEATURE_SPATIAL_INDEX_KEY = "fdbsql.feature.spatial_index_on";
-    public final static String FEATURE_BOOLEAN_INDEX_KEY = "fdbsql.feature.spatial_index_on";
 }

--- a/fdb-sql-layer-test-yaml/src/test/resources/com/foundationdb/sql/test/yaml/functional/test-sort-boolean.yaml
+++ b/fdb-sql-layer-test-yaml/src/test/resources/com/foundationdb/sql/test/yaml/functional/test-sort-boolean.yaml
@@ -1,0 +1,13 @@
+---
+- CreateTable: tb(id INT PRIMARY KEY, value BOOLEAN)
+---
+- Statement: INSERT INTO tb VALUES (1, true), (2, false)
+---
+- Statement: SELECT id, value FROM tb ORDER BY value
+- output_already_ordered: [[2, false], [1, true]]
+---
+- Statement: CREATE INDEX tb_b ON tb(value)
+---
+- Statement: SELECT id, value FROM tb ORDER BY value
+- output_already_ordered: [[2, false], [1, true]]
+...


### PR DESCRIPTION
Also bumps the data version for FDB and removes the old compromise check.