### PR TITLE
Update the StatusMonitor per the request of the Status Monitor team

### DIFF
--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/service/statusmonitor/StatusMonitorServiceImpl.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/service/statusmonitor/StatusMonitorServiceImpl.java
@@ -274,10 +274,10 @@ public class StatusMonitorServiceImpl implements StatusMonitorService, Service {
     private static final String INSTANCE_SQL =  "select server_store as store, server_jit_compiler_time as jit_compiler_time from information_schema.server_instance_summary";
     
     private static final String SERVERS = "servers";
-    private static final String SERVERS_SQL = "select * from information_schema.server_servers";
+    private static final String SERVERS_SQL = "select server_type, local_port, unix_timestamp(start_time) as start_time, session_count from information_schema.server_servers";
     
     private static final String SESSIONS = "sessions";
-    private static final String SESSIONS_SQL  = "select session_id, start_time, server_type, remote_address,"+ 
+    private static final String SESSIONS_SQL  = "select session_id, unix_timestamp(start_time) as start_time, server_type, remote_address,"+ 
         "query_count, failed_query_count, query_from_cache, logged_statements," +
         "call_statement_count, ddl_statement_count, dml_statement_count, select_statement_count," + 
         "other_statement_count from information_schema.server_sessions";
@@ -285,10 +285,10 @@ public class StatusMonitorServiceImpl implements StatusMonitorService, Service {
     private static final String STATISTICS = "statistics";
     private static final String STATISTICS_SQL = "select * from information_schema.server_statistics_summary";
     
-    private static final String GARBAGE_COLLECTORS = "garbage collectors";
+    private static final String GARBAGE_COLLECTORS = "garbage_collectors";
     private static final String GARBAGE_COLLECTORS_SQL = "select * from information_schema.server_garbage_collectors";
     
-    private static final String MEMORY_POOLS = "memory pools";
+    private static final String MEMORY_POOLS = "memory_pools";
     private static final String MEMORY_POOLS_SQL = "select * from information_schema.server_memory_pools";
     
     protected void summary (String name, String sql, JsonGenerator gen, boolean arrayWrapper) throws JsonGenerationException, IOException {

--- a/fdb-sql-layer-core/src/test/java/com/foundationdb/server/service/statusmonitor/StatusMonitorServiceIT.java
+++ b/fdb-sql-layer-core/src/test/java/com/foundationdb/server/service/statusmonitor/StatusMonitorServiceIT.java
@@ -90,7 +90,28 @@ public class StatusMonitorServiceIT extends FDBITBase {
             assertEquals(JsonToken.FIELD_NAME, parser.nextToken());
             assertEquals("servers", parser.getText());
             assertEquals(JsonToken.START_ARRAY, parser.nextToken());
-            parser.skipChildren();
+
+            // Check Servers array, which should have one object, the internal JDCB connection service.
+            
+            assertEquals(JsonToken.START_OBJECT, parser.nextToken());
+            assertEquals(JsonToken.FIELD_NAME, parser.nextToken());
+            assertEquals("server_type", parser.getText());
+            assertEquals(JsonToken.VALUE_STRING, parser.nextToken());
+            assertEquals(JsonToken.FIELD_NAME, parser.nextToken());
+            assertEquals("local_port", parser.getText());
+            
+            JsonToken port = parser.nextToken();
+            assertTrue (port == JsonToken.VALUE_NUMBER_INT || port == JsonToken.VALUE_NULL);
+            assertEquals(JsonToken.FIELD_NAME, parser.nextToken());
+            assertEquals("start_time", parser.getText());
+            assertEquals(JsonToken.VALUE_NUMBER_INT, parser.nextToken());
+            assertEquals(JsonToken.FIELD_NAME, parser.nextToken());
+            assertEquals("session_count", parser.getText());
+            assertEquals(JsonToken.VALUE_NUMBER_INT, parser.nextToken());
+            assertEquals(JsonToken.END_OBJECT, parser.nextToken());
+            assertEquals(JsonToken.END_ARRAY, parser.nextToken());
+            
+            
             assertEquals(JsonToken.FIELD_NAME, parser.nextToken());
             assertEquals("sessions", parser.getText());
             assertEquals(JsonToken.START_ARRAY, parser.nextToken());
@@ -100,11 +121,11 @@ public class StatusMonitorServiceIT extends FDBITBase {
             assertEquals(JsonToken.START_OBJECT, parser.nextToken());
             parser.skipChildren();
             assertEquals(JsonToken.FIELD_NAME, parser.nextToken());
-            assertEquals("garbage collectors", parser.getText());
+            assertEquals("garbage_collectors", parser.getText());
             assertEquals(JsonToken.START_ARRAY, parser.nextToken());
             parser.skipChildren();
             assertEquals(JsonToken.FIELD_NAME, parser.nextToken());
-            assertEquals("memory pools", parser.getText());
+            assertEquals("memory_pools", parser.getText());
             assertEquals(JsonToken.START_ARRAY, parser.nextToken());
             parser.skipChildren();
             assertEquals(JsonToken.END_OBJECT, parser.nextToken());


### PR DESCRIPTION
Two changes: 

- change the names with spaces (memory pools, garbage collectors) to use underscores
- Convert the start time columns to unix_timestamp()