### PR TITLE
Fix consistency checker for index bounds for key-comparables

### DIFF
--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/qp/storeadapter/indexcursor/ValueSortKeyAdapter.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/qp/storeadapter/indexcursor/ValueSortKeyAdapter.java
@@ -59,23 +59,8 @@ public class ValueSortKeyAdapter extends SortKeyAdapter<ValueSource, TPreparedEx
                                  TInstance[] types) {
         ValueSource loValueSource = loExpressions.value(f);
         ValueSource hiValueSource = hiExpressions.value(f);
-        if (loValueSource.isNull() && hiValueSource.isNull()) {
-            // OK, they're equal
-        } else if (loValueSource.isNull() || hiValueSource.isNull()) {
-            throw new IllegalArgumentException(String.format("lo: %s, hi: %s", loValueSource, hiValueSource));
-        } else {
-            TInstance type = types[f];
-            TPreparedExpression loEQHi =
-                    new TComparisonExpression(
-                            new TPreparedLiteral(type, loValueSource),
-                            Comparison.EQ,
-                            new TPreparedLiteral(type, hiValueSource)
-                    );
-            TEvaluatableExpression eval = loEQHi.build();
-            eval.evaluate();
-            if (!eval.resultValue().getBoolean()) {
-                throw new IllegalArgumentException();
-            }
+        if (!TClass.areEqual(loValueSource, hiValueSource)) {
+            throw new IllegalArgumentException(String.format("lo: %s <> hi: %s", loValueSource, hiValueSource));
         }
     }
 

--- a/fdb-sql-layer-test-yaml/src/test/resources/com/foundationdb/sql/test/yaml/bugs/test-issue-1660.yaml
+++ b/fdb-sql-layer-test-yaml/src/test/resources/com/foundationdb/sql/test/yaml/bugs/test-issue-1660.yaml
@@ -1,0 +1,11 @@
+#
+# bigint on multicolumn primary key caused wrong check error on select
+#
+---
+- CreateTable: test_table ( Id1 bigint NOT NULL, Id2 int NOT NULL, PRIMARY KEY (Id1, Id2) )
+---
+- Statement: INSERT INTO test_table VALUES (1, 1),(2, 2),(20, 1)
+---
+- Statement: SELECT * FROM test_table WHERE Id1 = 20 AND Id2 = 1;
+- output: [ [20, 1] ]
+...


### PR DESCRIPTION
The issue is that the declared type of the index column may not be the same as the either of the two identival bound values.