### PR TITLE
Null in index scan checking

### DIFF
--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/qp/expression/IndexBound.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/qp/expression/IndexBound.java
@@ -56,8 +56,8 @@ public class IndexBound
         this.columnSelector = columnSelector;
     }
     
-    public boolean isLiteralNull(int index) {
-        return unboundExpressions.isLiteralNull(index);
+    public boolean isLiteral(int index) {
+        return unboundExpressions.isLiteral(index);
     }
 
     // Object state
@@ -85,7 +85,7 @@ public class IndexBound
         }
         
         @Override 
-        public boolean isLiteralNull(int index) {
+        public boolean isLiteral(int index) {
             // Because this is built off a row queried from the database, 
             // none of the values can ever be a literal null.
             return false;

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/qp/expression/IndexBound.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/qp/expression/IndexBound.java
@@ -55,6 +55,10 @@ public class IndexBound
         this.unboundExpressions = unboundExpressions;
         this.columnSelector = columnSelector;
     }
+    
+    public boolean isLiteralNull(int index) {
+        return unboundExpressions.isLiteralNull(index);
+    }
 
     // Object state
 
@@ -78,6 +82,13 @@ public class IndexBound
         @Override
         public String toString() {
             return String.valueOf(expressions);
+        }
+        
+        @Override 
+        public boolean isLiteralNull(int index) {
+            // Because this is built off a row queried from the database, 
+            // none of the values can ever be a literal null.
+            return false;
         }
 
         public PreBoundExpressions(ValueRecord expressions) {

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/qp/expression/RowBasedUnboundExpressions.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/qp/expression/RowBasedUnboundExpressions.java
@@ -31,8 +31,12 @@ import com.foundationdb.server.types.value.ValueRecord;
 import com.foundationdb.server.types.value.ValueSource;
 import com.foundationdb.server.types.texpressions.TNullExpression;
 import com.foundationdb.server.types.texpressions.TPreparedExpression;
+import com.foundationdb.server.types.texpressions.TPreparedLiteral;
 
 import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class RowBasedUnboundExpressions implements UnboundExpressions {
     @Override
@@ -73,12 +77,13 @@ public final class RowBasedUnboundExpressions implements UnboundExpressions {
     }
     
     public boolean isLiteralNull(int index) {
-        return pExprs.get(index) instanceof TNullExpression;
+        return pExprs.get(index) instanceof TNullExpression || 
+                pExprs.get(index) instanceof TPreparedLiteral;
     }
 
     private final List<TPreparedExpression> pExprs;
     private final RowType rowType;
-
+    private static final Logger LOG = LoggerFactory.getLogger(RowBasedUnboundExpressions.class);
     private static class ExpressionsAndBindings implements ValueRecord {
 
         @Override

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/qp/expression/RowBasedUnboundExpressions.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/qp/expression/RowBasedUnboundExpressions.java
@@ -75,8 +75,9 @@ public final class RowBasedUnboundExpressions implements UnboundExpressions {
         this.pExprs = pExprs;
         this.rowType = rowType.schema().newProjectType(pExprs);
     }
-    
-    public boolean isLiteralNull(int index) {
+
+    @Override
+    public boolean isLiteral(int index) {
         return pExprs.get(index).isLiteral();
     }
 

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/qp/expression/RowBasedUnboundExpressions.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/qp/expression/RowBasedUnboundExpressions.java
@@ -86,7 +86,14 @@ public final class RowBasedUnboundExpressions implements UnboundExpressions {
         {
             expressionRow = new ExpressionRow(rowType, context, bindings, pExprs);
         }
+        
+        @Override
+        public String toString() {
+            return expressionRow.toString();
+        }
 
         private final ExpressionRow expressionRow;
+        
+        
     }
 }

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/qp/expression/RowBasedUnboundExpressions.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/qp/expression/RowBasedUnboundExpressions.java
@@ -29,14 +29,9 @@ import com.foundationdb.server.explain.Label;
 import com.foundationdb.server.explain.Type;
 import com.foundationdb.server.types.value.ValueRecord;
 import com.foundationdb.server.types.value.ValueSource;
-import com.foundationdb.server.types.texpressions.TNullExpression;
 import com.foundationdb.server.types.texpressions.TPreparedExpression;
-import com.foundationdb.server.types.texpressions.TPreparedLiteral;
 
 import java.util.List;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public final class RowBasedUnboundExpressions implements UnboundExpressions {
     @Override

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/qp/expression/RowBasedUnboundExpressions.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/qp/expression/RowBasedUnboundExpressions.java
@@ -77,13 +77,11 @@ public final class RowBasedUnboundExpressions implements UnboundExpressions {
     }
     
     public boolean isLiteralNull(int index) {
-        return pExprs.get(index) instanceof TNullExpression || 
-                pExprs.get(index) instanceof TPreparedLiteral;
+        return pExprs.get(index).isLiteral();
     }
 
     private final List<TPreparedExpression> pExprs;
     private final RowType rowType;
-    private static final Logger LOG = LoggerFactory.getLogger(RowBasedUnboundExpressions.class);
     private static class ExpressionsAndBindings implements ValueRecord {
 
         @Override

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/qp/expression/RowBasedUnboundExpressions.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/qp/expression/RowBasedUnboundExpressions.java
@@ -29,6 +29,7 @@ import com.foundationdb.server.explain.Label;
 import com.foundationdb.server.explain.Type;
 import com.foundationdb.server.types.value.ValueRecord;
 import com.foundationdb.server.types.value.ValueSource;
+import com.foundationdb.server.types.texpressions.TNullExpression;
 import com.foundationdb.server.types.texpressions.TPreparedExpression;
 
 import java.util.List;
@@ -69,6 +70,10 @@ public final class RowBasedUnboundExpressions implements UnboundExpressions {
         }
         this.pExprs = pExprs;
         this.rowType = rowType.schema().newProjectType(pExprs);
+    }
+    
+    public boolean isLiteralNull(int index) {
+        return pExprs.get(index) instanceof TNullExpression;
     }
 
     private final List<TPreparedExpression> pExprs;

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/qp/expression/UnboundExpressions.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/qp/expression/UnboundExpressions.java
@@ -26,4 +26,5 @@ import com.foundationdb.server.types.value.ValueRecord;
 public interface UnboundExpressions {
     ValueRecord get(QueryContext context, QueryBindings bindings);
     CompoundExplainer getExplainer(ExplainContext context);
+    boolean isLiteralNull(int index);
 }

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/qp/expression/UnboundExpressions.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/qp/expression/UnboundExpressions.java
@@ -26,5 +26,5 @@ import com.foundationdb.server.types.value.ValueRecord;
 public interface UnboundExpressions {
     ValueRecord get(QueryContext context, QueryBindings bindings);
     CompoundExplainer getExplainer(ExplainContext context);
-    boolean isLiteralNull(int index);
+    boolean isLiteral(int index);
 }

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/qp/operator/RowCursorImpl.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/qp/operator/RowCursorImpl.java
@@ -68,6 +68,12 @@ public abstract class RowCursorImpl implements RowCursor {
         state = CursorLifecycle.CursorState.IDLE;
     }
 
+    // Used in IndexCursorUnidirections#jump() to reactivate the cursor
+    protected void setActive() {
+        CursorLifecycle.checkIdleOrActive(this);
+        state = CursorLifecycle.CursorState.ACTIVE;
+    }
+    
     @Override
     public boolean isIdle()
     {

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/qp/storeadapter/FDBGroupCursor.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/qp/storeadapter/FDBGroupCursor.java
@@ -20,7 +20,6 @@ import com.foundationdb.ais.model.Group;
 import com.foundationdb.qp.operator.CursorLifecycle;
 import com.foundationdb.qp.operator.GroupCursor;
 import com.foundationdb.qp.operator.RowCursorImpl;
-import com.foundationdb.qp.operator.StoreAdapter;
 import com.foundationdb.qp.row.HKey;
 import com.foundationdb.qp.row.Row;
 import com.foundationdb.qp.rowtype.Schema;

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/qp/storeadapter/indexcursor/IndexCursorUnidirectional.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/qp/storeadapter/indexcursor/IndexCursorUnidirectional.java
@@ -240,13 +240,13 @@ class IndexCursorUnidirectional<S> extends IndexCursor
                 // SELECT * FROM t where x is NULL which should. 
                 // if this case is true, there will not be any rows returned, so
                 // idle the cursor, and return no rows quickly.
-                if (keyAdapter.isNull(startValues[f]) && !start.isLiteralNull(f)) {
+                if (keyAdapter.isNull(startValues[f]) && !start.isLiteral(f)) {
                     LOG.debug("Found stop case for non-literal null in start");
                     setIdle();
                     return;
                 }
                 endValues[f] = keyAdapter.get(endExpressions, f);
-                if (keyAdapter.isNull(endValues[f]) && !end.isLiteralNull(f)) {
+                if (keyAdapter.isNull(endValues[f]) && !end.isLiteral(f)) {
                     LOG.debug("Found stop case for non-literal null in end");
                     setIdle();
                     return;

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/FDBStore.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/FDBStore.java
@@ -530,11 +530,12 @@ public class FDBStore extends AbstractStore<FDBStore,FDBStoreData,FDBStorageDesc
         }
     }
 
+    // Test only traversal. 
     @Override
     public void traverse(Session session, Group group, TreeRecordVisitor visitor) {
         visitor.initialize(session, this);
         FDBStoreData storeData = createStoreData(session, group);
-        groupIterator(session, storeData);
+        groupIterator(session, storeData,  FDBScanTransactionOptions.NORMAL);
         while (storeData.next()) {
             Row row = expandGroupData(session, storeData, SchemaCache.globalSchema(group.getAIS()));
             visitor.visit(storeData.persistitKey, row);
@@ -546,6 +547,7 @@ public class FDBStore extends AbstractStore<FDBStore,FDBStoreData,FDBStorageDesc
         return expandRow(session, storeData, schema);
     }
     
+    // Test only Traversal
     @Override
     public <V extends IndexVisitor<Key, Value>> V traverse(Session session, Index index, V visitor, long scanTimeLimit, long sleepTime) {
         FDBStoreData storeData = createStoreData(session, index);
@@ -630,13 +632,6 @@ public class FDBStore extends AbstractStore<FDBStore,FDBStoreData,FDBStorageDesc
     public enum GroupIteratorBoundary { 
         START, END, KEY, NEXT_KEY, 
         FIRST_DESCENDANT, LAST_DESCENDANT
-    }
-
-    /** Iterate over the whole group. */
-    public void groupIterator(Session session, FDBStoreData storeData) {
-        groupIterator(session, storeData, 
-                      GroupIteratorBoundary.START, GroupIteratorBoundary.END, 
-                      Transaction.ROW_LIMIT_UNLIMITED, FDBScanTransactionOptions.NORMAL);
     }
 
     /** Iterate over just <code>storeData.persistitKey</code>, if present. */

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/texpressions/SubqueryTExpression.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/texpressions/SubqueryTExpression.java
@@ -43,6 +43,11 @@ abstract class SubqueryTExpression implements TPreparedExpression {
         states.put(Label.BINDING_POSITION, PrimitiveExplainer.getInstance(bindingPosition));
         return new CompoundExplainer(Type.SUBQUERY, states);
     }
+    
+    @Override
+    public boolean isLiteral() {
+        return false;
+    }
 
     // for use by subclasses
 

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/texpressions/TCastExpression.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/texpressions/TCastExpression.java
@@ -81,6 +81,11 @@ public final class TCastExpression implements TPreparedExpression {
         return "CAST(" + input + " AS " + targetInstance + ")";
     }
 
+    @Override
+    public boolean isLiteral() {
+        return false;
+    }
+
     public TCastExpression(TPreparedExpression input, TCast cast, TInstance targetInstance) {
         this.input = input;
         this.cast = cast;

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/texpressions/TComparisonExpressionBase.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/texpressions/TComparisonExpressionBase.java
@@ -92,6 +92,11 @@ public abstract class TComparisonExpressionBase implements TPreparedExpression {
         return left + " " + comparison + ' ' + right;
     }
 
+    @Override
+    public boolean isLiteral() {
+        return false;
+    }
+
     public TComparisonExpressionBase(TPreparedExpression left, Comparison comparison, TPreparedExpression right) {
         this.left = left;
         this.comparison = comparison;

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/texpressions/TNullExpression.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/texpressions/TNullExpression.java
@@ -61,6 +61,11 @@ public final class TNullExpression implements TPreparedExpression {
     public String toString() {
         return "Literal(NULL)";
     }
+    
+    @Override
+    public boolean isLiteral() {
+        return true;
+    }
 
     private final TInstance type;
 

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/texpressions/TPreparedBoundField.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/texpressions/TPreparedBoundField.java
@@ -61,6 +61,11 @@ public final class TPreparedBoundField implements TPreparedExpression {
         return "Bound(" + rowPosition + ',' + fieldExpression + ')';
     }
 
+    @Override
+    public boolean isLiteral() {
+        return false;
+    }
+
     public TPreparedBoundField(RowType rowType, int rowPosition, int fieldPosition) {
         fieldExpression = new TPreparedField(rowType.typeAt(fieldPosition), fieldPosition);
         this.rowPosition = rowPosition;

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/texpressions/TPreparedExpression.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/texpressions/TPreparedExpression.java
@@ -26,4 +26,5 @@ public interface TPreparedExpression extends Explainable {
     TPreptimeValue evaluateConstant(QueryContext queryContext);
     TInstance resultType();
     TEvaluatableExpression build();
+    boolean isLiteral();
 }

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/texpressions/TPreparedField.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/texpressions/TPreparedField.java
@@ -59,6 +59,11 @@ public final class TPreparedField implements TPreparedExpression {
         return "Field(" + fieldIndex + ')';
     }
 
+    @Override
+    public boolean isLiteral() {
+        return false;
+    }
+
     public TPreparedField(TInstance typeInstance, int fieldIndex) {
         this.typeInstance = typeInstance;
         this.fieldIndex = fieldIndex;

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/texpressions/TPreparedFunction.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/texpressions/TPreparedFunction.java
@@ -88,6 +88,11 @@ public final class TPreparedFunction implements TPreparedExpression {
         return overload.toString(inputs, resultType);
     }
 
+    @Override
+    public boolean isLiteral() {
+        return false;
+    }
+
     public TPreparedFunction(TValidatedScalar overload,
                              TInstance resultType,
                              List<? extends TPreparedExpression> inputs)

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/texpressions/TPreparedLiteral.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/texpressions/TPreparedLiteral.java
@@ -81,6 +81,11 @@ public final class TPreparedLiteral implements TPreparedExpression {
             this.value = value;
         }
     }
+    
+    public TPreparedLiteral (ValueSource value) {
+        this.type = value.getType();
+        this.value = value;
+    }
 
     private final TInstance type;
     private final ValueSource value;

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/texpressions/TPreparedLiteral.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/texpressions/TPreparedLiteral.java
@@ -71,6 +71,11 @@ public final class TPreparedLiteral implements TPreparedExpression {
         return sb.toString();
     }
 
+    @Override
+    public boolean isLiteral() {
+        return true;
+    }
+
     public TPreparedLiteral(TInstance type, ValueSource value) {
         if (type == null) {
             this.type = null;

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/texpressions/TPreparedParameter.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/texpressions/TPreparedParameter.java
@@ -60,6 +60,11 @@ public final class TPreparedParameter implements TPreparedExpression {
         return "Variable(pos=" + position + ')';
     }
 
+    @Override
+    public boolean isLiteral() {
+        return false;
+    }
+
     public TPreparedParameter(int position, TInstance type) {
         this.position = position;
         this.type = type;

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/texpressions/TSequenceNextValueExpression.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/texpressions/TSequenceNextValueExpression.java
@@ -70,6 +70,10 @@ public class TSequenceNextValueExpression implements TPreparedExpression
         return new CompoundExplainer(Type.FUNCTION, states);
     }
 
+    @Override
+    public boolean isLiteral() {
+        return false;
+    }
 
     private class InnerEvaluation implements TEvaluatableExpression
     {

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/texpressions/TValidatedScalar.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/texpressions/TValidatedScalar.java
@@ -19,8 +19,6 @@ package com.foundationdb.server.types.texpressions;
 
 import com.foundationdb.server.explain.*;
 import com.foundationdb.server.types.LazyList;
-import com.foundationdb.server.types.ReversedLazyList;
-import com.foundationdb.server.types.TClass;
 import com.foundationdb.server.types.TExecutionContext;
 import com.foundationdb.server.types.TInputSet;
 import com.foundationdb.server.types.TInstance;

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/sql/server/ServerJavaRoutineTExpression.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/sql/server/ServerJavaRoutineTExpression.java
@@ -30,7 +30,6 @@ import com.foundationdb.server.explain.std.TExpressionExplainer;
 import com.foundationdb.server.types.TInstance;
 import com.foundationdb.server.types.TPreptimeValue;
 import com.foundationdb.server.types.value.*;
-import com.foundationdb.server.types.value.Value;
 import com.foundationdb.server.types.texpressions.TEvaluatableExpression;
 import com.foundationdb.server.types.texpressions.TPreparedExpression;
 import com.foundationdb.server.types.value.ValueSource;
@@ -97,6 +96,11 @@ public abstract class ServerJavaRoutineTExpression implements TPreparedExpressio
             evals.add(input.build());
         }
         return new TEvaluatableJavaRoutine(routine, evals);
+    }
+
+    @Override
+    public boolean isLiteral() {
+        return false;
     }
 
     protected abstract ServerJavaRoutine javaRoutine(ServerQueryContext context,

--- a/fdb-sql-layer-core/src/test/java/com/foundationdb/server/test/ExpressionGenerators.java
+++ b/fdb-sql-layer-core/src/test/java/com/foundationdb/server/test/ExpressionGenerators.java
@@ -213,6 +213,11 @@ public final class ExpressionGenerators {
                     }
 
                     @Override
+                    public boolean isLiteral() {
+                        return false;
+                    }
+
+                    @Override
                     public TEvaluatableExpression build() {
                         final TEvaluatableExpression eval = expr.build();
                         return new TEvaluatableExpression() {

--- a/fdb-sql-layer-core/src/test/java/com/foundationdb/server/test/it/qp/UniqueIndexScanIT.java
+++ b/fdb-sql-layer-core/src/test/java/com/foundationdb/server/test/it/qp/UniqueIndexScanIT.java
@@ -17,8 +17,14 @@
 
 package com.foundationdb.server.test.it.qp;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import com.foundationdb.qp.expression.IndexBound;
 import com.foundationdb.qp.expression.IndexKeyRange;
+import com.foundationdb.qp.expression.RowBasedUnboundExpressions;
+import com.foundationdb.qp.expression.UnboundExpressions;
 import com.foundationdb.qp.operator.Cursor;
 import com.foundationdb.qp.operator.Operator;
 import com.foundationdb.qp.row.Row;
@@ -26,10 +32,16 @@ import com.foundationdb.qp.rowtype.IndexRowType;
 import com.foundationdb.qp.rowtype.Schema;
 import com.foundationdb.server.api.dml.ColumnSelector;
 import com.foundationdb.server.api.dml.SetColumnSelector;
+import com.foundationdb.server.types.texpressions.TNullExpression;
+import com.foundationdb.server.types.texpressions.TPreparedExpression;
+import com.foundationdb.server.types.texpressions.TPreparedLiteral;
+import com.foundationdb.server.types.value.Value;
+
 import org.junit.Test;
 
 import static com.foundationdb.qp.operator.API.cursor;
 import static com.foundationdb.qp.operator.API.indexScan_Default;
+import static org.junit.Assert.fail;
 
 // Like IndexScanIT, but testing unique indexes and the handling of duplicate nulls
 
@@ -502,11 +514,14 @@ public class UniqueIndexScanIT extends OperatorITBase
     }
 
     // For use by this class
-
+    
     private IndexKeyRange startAtNull(IndexRowType indexRowType, boolean loInclusive, int hi, boolean hiInclusive)
     {
+        
+        UnboundExpressions row = new RowBasedUnboundExpressions (indexRowType, 
+                Arrays.asList((TPreparedExpression)new TNullExpression(indexRowType.typeAt(0))));
         return IndexKeyRange.bounded(indexRowType,
-                                     new IndexBound(row(indexRowType, new Object[]{null}), COLUMN_0),
+                                     new IndexBound(row, COLUMN_0),
                                      loInclusive,
                                      new IndexBound(row(indexRowType, hi), COLUMN_0),
                                      hiInclusive);

--- a/fdb-sql-layer-test-yaml/src/test/resources/com/foundationdb/sql/test/yaml/bugs/test-bug-null-in-indexscan.yaml
+++ b/fdb-sql-layer-test-yaml/src/test/resources/com/foundationdb/sql/test/yaml/bugs/test-bug-null-in-indexscan.yaml
@@ -1,0 +1,24 @@
+---
+- CreateTable: t(id INT PRIMARY KEY, x INT, INDEX(x))
+---
+- Statement: INSERT INTO t VALUES (1,10),(2,null),(3,30);
+---
+- Statement: SELECT * FROM t WHERE x=null
+- row_count: 0
+---
+- Statement: SELECT * from t WHERE x IS NULL;
+- row_count: 1
+---
+- Statement: SELECT * FROM t WHERE x = ?
+- params: [[null]]
+- row_count: 1
+---
+- Statement:  PREPARE foo AS SELECT * FROM t WHERE x = ?
+---
+- Statement: EXECUTE foo(null);
+- row_count: 1
+---
+- Statement: PREPARE foo2 AS SELECT * FROM T where x between ? and ?
+---
+- Statement: EXECUTE foo2 (1, NULL)
+...

--- a/fdb-sql-layer-test-yaml/src/test/resources/com/foundationdb/sql/test/yaml/bugs/test-bug-null-in-indexscan.yaml
+++ b/fdb-sql-layer-test-yaml/src/test/resources/com/foundationdb/sql/test/yaml/bugs/test-bug-null-in-indexscan.yaml
@@ -11,14 +11,25 @@
 ---
 - Statement: SELECT * FROM t WHERE x = ?
 - params: [[null]]
-- row_count: 1
+- row_count: 0
 ---
 - Statement:  PREPARE foo AS SELECT * FROM t WHERE x = ?
 ---
 - Statement: EXECUTE foo(null);
-- row_count: 1
+- row_count: 0
 ---
 - Statement: PREPARE foo2 AS SELECT * FROM T where x between ? and ?
 ---
 - Statement: EXECUTE foo2 (1, NULL)
+- row_count: 0
+---
+- Statement: EXECUTE foo2 (null, 1)
+- row_count: 0
+---
+- Statement: SELECT * from t where x IN (null);
+- row_count: 0
+---
+- Statement: SELECT * From t where x in (?);
+- params: [[null]]
+- row_count: 0
 ...


### PR DESCRIPTION
Address one more case of using NULL in statements which use an index scan incorrectly. In this case `SELECT * FROM t WHERE x = ?` where the parameter is set to `null` should return no rows, but the query  `SELECT * from t WHERE x IS NULL;` should return rows. In `IndexCursorUnidirectional.java`, there isn't any way to distinguish between these two cases. This branch adds one. 

It checks the underlying implementations of the expressions used for the range on the scan to ensure the source is a literal null or not. If so, the second query is assumed and does the range correctly. If not a literal, the first form is assumed, and the cursor is flagged to not return any rows. 

To make the IndexCursorUnidirectional as aggressive about skipping the processing, including creating the underlying FDBIterator and K/Vstore scan, it uses the cursor state Idle setting. Because the implementation for this case is aggressive (to avoid the expensive transaction processing), the `IndexCursorUnidirectional#jump()` cursor processing needs to reset the cursor from idle to active to allow correct processing. 