### PR TITLE
Make PlanGenerator#generateIndexScan() use ascending order for index scans

### DIFF
--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/sql/optimizer/rule/PlanGenerator.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/sql/optimizer/rule/PlanGenerator.java
@@ -205,7 +205,7 @@ public class PlanGenerator {
         Ordering ordering = API.ordering();
         for (int i = 0; i < nkeys; i++) {
             ordering.append(new TPreparedField(indexType.typeAt(i), i),
-                            false);
+                            true); // Ascending order
         }
 
         return API.indexScan_Default(indexType, indexRange, ordering);


### PR DESCRIPTION
One line fix