### PR TITLE
Helper for computing precision and scale from BigDecimal

### DIFF
--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/rowdata/ConversionHelperBigDecimal.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/rowdata/ConversionHelperBigDecimal.java
@@ -18,6 +18,7 @@
 package com.foundationdb.server.rowdata;
 
 import com.foundationdb.server.AkServerUtil;
+import com.foundationdb.server.types.common.BigDecimalWrapperImpl;
 import com.foundationdb.util.AkibanAppender;
 
 import java.math.BigDecimal;
@@ -189,13 +190,9 @@ public final class ConversionHelperBigDecimal {
 
     public static String normalizeToString(BigDecimal value, int declPrec, int declScale) {
         // First, we have to turn the value into one that fits the FieldDef's constraints.
-        int valuePrec = value.precision();
-        int valueScale = value.scale();
+        int valuePrec = BigDecimalWrapperImpl.sqlPrecision(value);
+        int valueScale = BigDecimalWrapperImpl.sqlScale(value);
         assert valueScale >= 0 : value;
-        // MySQL sees "0.0123" as DECIMAL(4, 4). Java sees it as DECIMAL(3, 4). So, just do a simple conversion.
-        if (valuePrec < valueScale) {
-            valuePrec = valueScale;
-        }
         int valueIntDigits = valuePrec - valueScale;
         int declIntDigits = declPrec - declScale;
         if (valueIntDigits > declIntDigits) {

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/common/BigDecimalWrapperImpl.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/common/BigDecimalWrapperImpl.java
@@ -24,6 +24,21 @@ public class BigDecimalWrapperImpl implements BigDecimalWrapper {
 
     public static final BigDecimalWrapperImpl ZERO = new BigDecimalWrapperImpl(BigDecimal.ZERO);
 
+    public static int sqlPrecision(BigDecimal bd) {
+        int precision = bd.precision();
+        int scale = bd.scale();
+        if (precision < scale) {
+            // BigDecimal interprets something like "0.01" as having a scale of 2 and precision of 1.
+            precision = scale;
+        }
+        return precision;
+    }
+
+    public static int sqlScale(BigDecimal bd) {
+        return bd.scale();
+    }
+
+
     private BigDecimal value;
 
     public BigDecimalWrapperImpl(BigDecimal value) {
@@ -135,13 +150,13 @@ public class BigDecimalWrapperImpl implements BigDecimalWrapper {
     @Override
     public int getScale()
     {
-        return value.scale();
+        return sqlScale(value);
     }
 
     @Override
     public int getPrecision()
     {
-        return value.precision();
+        return sqlPrecision(value);
     }
 
     @Override

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/common/types/TBigDecimal.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/common/types/TBigDecimal.java
@@ -304,12 +304,14 @@ public class TBigDecimal extends TClassBase {
             }
             int allowedScale = typeInstance.attribute(DecimalAttribute.SCALE);
             int allowedPrecision = typeInstance.attribute(DecimalAttribute.PRECISION);
-            if (allowedPrecision < bigDecimal.precision()) {
-                throw new AkibanInternalException("precision of " + bigDecimal.precision()
+            int actualScale = BigDecimalWrapperImpl.sqlScale(bigDecimal);
+            int actualPrecision = BigDecimalWrapperImpl.sqlPrecision(bigDecimal);
+            if (allowedPrecision < actualPrecision) {
+                throw new AkibanInternalException("precision of " + actualPrecision
                         + " is greater than " + allowedPrecision + " for value " + bigDecimal);
             }
-            if (allowedScale < bigDecimal.scale()) {
-                throw new AkibanInternalException("scale of " + bigDecimal.scale()
+            if (allowedScale < actualScale) {
+                throw new AkibanInternalException("scale of " + actualScale
                         + " is greater than " + allowedScale + " for value " + bigDecimal);
             }
             BigDecimalWrapper wrapper = new BigDecimalWrapperImpl(bigDecimal).round(allowedScale);

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/value/ValueSources.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/types/value/ValueSources.java
@@ -238,13 +238,7 @@ public final class ValueSources {
         }
         else if (object instanceof BigDecimal) {
             BigDecimal bd = (BigDecimal) object;
-            int precision = bd.precision();
-            int scale = bd.scale();
-            if (precision < scale) {
-                // BigDecimal interprets something like "0.01" as having a scale of 2 and precision of 1.
-                precision = scale;
-            }
-            type = MNumeric.DECIMAL.instance(precision, scale, false);
+            type = MNumeric.DECIMAL.instance(BigDecimalWrapperImpl.sqlPrecision(bd), BigDecimalWrapperImpl.sqlScale(bd), false);
             value = new Value(type);
             value.putObject(new BigDecimalWrapperImpl(bd));
         }

--- a/fdb-sql-layer-core/src/test/java/com/foundationdb/server/types/DecimalSelfCastTest.java
+++ b/fdb-sql-layer-core/src/test/java/com/foundationdb/server/types/DecimalSelfCastTest.java
@@ -23,6 +23,7 @@ import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Collection;
 
+import com.foundationdb.server.types.value.ValueSources;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -72,7 +73,7 @@ public class DecimalSelfCastTest {
 
     @Test
     public void checkSelfCast() {
-        Value start = new Value (MNumeric.DECIMAL.instance(source.precision(), source.scale(), false));
+        Value start = ValueSources.fromObject(source);
         start.putObject(new BigDecimalWrapperImpl(source));
         Value target = new Value (MNumeric.DECIMAL.instance(precision, scale, false));
         

--- a/fdb-sql-layer-core/src/test/java/com/foundationdb/server/types/value/ValueSourcesTest.java
+++ b/fdb-sql-layer-core/src/test/java/com/foundationdb/server/types/value/ValueSourcesTest.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (C) 2009-2015 FoundationDB, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.foundationdb.server.types.value;
+
+import com.foundationdb.server.types.Attribute;
+import com.foundationdb.server.types.TClass;
+import com.foundationdb.server.types.TInstance;
+import com.foundationdb.server.types.common.BigDecimalWrapper;
+import com.foundationdb.server.types.common.BigDecimalWrapperImpl;
+import com.foundationdb.server.types.common.types.DecimalAttribute;
+import com.foundationdb.server.types.common.types.TBigDecimal;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.junit.Assert.assertThat;
+
+import static com.foundationdb.server.types.value.ValueSources.*;
+
+public class ValueSourcesTest
+{
+    private static void checkType(Class<? extends TClass> clazz,
+                                  Attribute attr0, int value0,
+                                  Attribute attr1, int value1,
+                                  Value v) {
+        TInstance type = v.getType();
+        assertThat(type.typeClass(), is(instanceOf(clazz)));
+        if(attr0 != null) {
+            assertThat(attr0.name(), type.attribute(attr0), is(equalTo(value0)));
+        }
+        if(attr1 != null) {
+            assertThat(attr1.name(), type.attribute(attr1), is(equalTo(value1)));
+        }
+    }
+
+    private static void checkDecimal(int precision, int scale, Value v) {
+        checkType(TBigDecimal.class, DecimalAttribute.PRECISION, precision, DecimalAttribute.SCALE, scale, v);
+    }
+
+    private static void checkDecimal(int precision, int scale, String decimalStr) {
+        BigDecimalWrapper wrapper = new BigDecimalWrapperImpl(new BigDecimal(decimalStr));
+        checkDecimal(precision, scale, fromObject(wrapper.asBigDecimal()));
+        checkDecimal(precision, scale, fromObject(wrapper));
+    }
+
+    @Test
+    public void fromObjectBigDecimals() {
+        checkDecimal(6, 3, "-123.456");
+        checkDecimal(2, 1, "-1.0");
+        checkDecimal(2, 2, ".00");
+        checkDecimal(1, 1, ".0");
+        checkDecimal(1, 1, "0.0");
+        checkDecimal(1, 0, "0.");
+        checkDecimal(1, 0, "00.");
+        checkDecimal(4, 4, "0.0005");
+        checkDecimal(2, 1, "1.0");
+        checkDecimal(6, 3, "123.456");
+    }
+}


### PR DESCRIPTION
Fixes bug when ValueSources is handed a BigDecimalWrapper with a prec/scale that don't match SQL's view (e.g. 0.01).