### PR TITLE
Key selector end exclusive flag

### DIFF
--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/qp/storeadapter/PersistitIterationHelper.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/qp/storeadapter/PersistitIterationHelper.java
@@ -84,7 +84,7 @@ public class PersistitIterationHelper implements IterationHelper
     }
 
     @Override
-    public void preload(Direction dir) {
+    public void preload(Direction dir, boolean endInclusive) {
     }
 
     // PersistitIterationHelper interface

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/qp/storeadapter/indexcursor/IndexCursorUnidirectional.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/qp/storeadapter/indexcursor/IndexCursorUnidirectional.java
@@ -360,6 +360,8 @@ class IndexCursorUnidirectional<S> extends IndexCursor
 
     // TODO : Once the Persistit storage engine is removed, the FDB storage engine
     // does a correct job of selecting the range, and this method can be removed.
+    // TODO : Except beforeStart() also used to manage exceptions in the list:
+    // e.g. SELECT * from t where t.id != 2 order by t.id ; 
     protected boolean beforeStart(Row row)
     {
         boolean beforeStart = false;
@@ -368,6 +370,7 @@ class IndexCursorUnidirectional<S> extends IndexCursor
             int c = current.compareTo(startKey, startBoundColumns) * direction;
             beforeStart = c < 0 || c == 0 && !startInclusive;
         }
+        //assert false == beforeStart : row;
         return beforeStart;
     }
 
@@ -383,6 +386,7 @@ class IndexCursorUnidirectional<S> extends IndexCursor
             int c = current.compareTo(endKey, endBoundColumns) * direction;
             pastEnd = c > 0 || c == 0 && !endInclusive;
         }
+        assert false == pastEnd : row;
         return pastEnd;
     }
 
@@ -494,7 +498,7 @@ class IndexCursorUnidirectional<S> extends IndexCursor
             pastStart = false;
         }
         keyComparison = initialKeyComparison;
-        iterationHelper.preload(keyComparison);
+        iterationHelper.preload(keyComparison, this.endInclusive);
     }
 
     private Index index()

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/qp/storeadapter/indexcursor/IndexCursorUnidirectional.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/qp/storeadapter/indexcursor/IndexCursorUnidirectional.java
@@ -360,8 +360,6 @@ class IndexCursorUnidirectional<S> extends IndexCursor
 
     // TODO : Once the Persistit storage engine is removed, the FDB storage engine
     // does a correct job of selecting the range, and this method can be removed.
-    // TODO : Except beforeStart() also used to manage exceptions in the list:
-    // e.g. SELECT * from t where t.id != 2 order by t.id ; 
     protected boolean beforeStart(Row row)
     {
         boolean beforeStart = false;

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/qp/storeadapter/indexcursor/IndexCursorUnidirectional.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/qp/storeadapter/indexcursor/IndexCursorUnidirectional.java
@@ -368,7 +368,9 @@ class IndexCursorUnidirectional<S> extends IndexCursor
             int c = current.compareTo(startKey, startBoundColumns) * direction;
             beforeStart = c < 0 || c == 0 && !startInclusive;
         }
-        assert false == beforeStart : keyRange + " to " + row;
+        //TODO: all of the FDB Tests pass with this enabled, but will cause 
+        // Persistit index use to fail. 
+        //assert false == beforeStart : keyRange + " to " + row;
         return beforeStart;
     }
 
@@ -384,7 +386,9 @@ class IndexCursorUnidirectional<S> extends IndexCursor
             int c = current.compareTo(endKey, endBoundColumns) * direction;
             pastEnd = c > 0 || c == 0 && !endInclusive;
         }
-        assert false == pastEnd : keyRange + " to " + row;
+        //TODO: all of the FDB Tests pass with this enabled, but will cause 
+        // Persistit index use to fail. 
+        //assert false == pastEnd : keyRange + " to " + row;
         return pastEnd;
     }
 

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/qp/storeadapter/indexcursor/IndexCursorUnidirectional.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/qp/storeadapter/indexcursor/IndexCursorUnidirectional.java
@@ -370,7 +370,7 @@ class IndexCursorUnidirectional<S> extends IndexCursor
             int c = current.compareTo(startKey, startBoundColumns) * direction;
             beforeStart = c < 0 || c == 0 && !startInclusive;
         }
-        //assert false == beforeStart : row;
+        assert false == beforeStart : keyRange + " to " + row;
         return beforeStart;
     }
 
@@ -386,7 +386,7 @@ class IndexCursorUnidirectional<S> extends IndexCursor
             int c = current.compareTo(endKey, endBoundColumns) * direction;
             pastEnd = c > 0 || c == 0 && !endInclusive;
         }
-        assert false == pastEnd : row;
+        assert false == pastEnd : keyRange + " to " + row;
         return pastEnd;
     }
 

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/qp/storeadapter/indexcursor/IterationHelper.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/qp/storeadapter/indexcursor/IterationHelper.java
@@ -56,5 +56,5 @@ public interface IterationHelper
      * Start cursor for given direction if that can be done asynchronously.
      * @param dir The direction to advance in.
      */
-    void preload(Direction dir);
+    void preload(Direction dir, boolean endInclusive);
 }

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/FDBStore.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/FDBStore.java
@@ -561,7 +561,7 @@ public class FDBStore extends AbstractStore<FDBStore,FDBStoreData,FDBStorageDesc
         else {
             transactionOptions = FDBScanTransactionOptions.SNAPSHOT;
         }
-        indexIterator(session, storeData, false, false, false, transactionOptions);
+        indexIterator(session, storeData, false, false, true, false, transactionOptions);
         while(storeData.next()) {
             // Key
             unpackKey(storeData);
@@ -673,14 +673,14 @@ public class FDBStore extends AbstractStore<FDBStore,FDBStoreData,FDBStorageDesc
     /** Iterate over the whole index. */
     public void indexIterator(Session session, FDBStoreData storeData,
                               FDBScanTransactionOptions transactionOptions) {
-        indexIterator(session, storeData, false, false, false, transactionOptions);
+        indexIterator(session, storeData, false, false, true, false, transactionOptions);
     }
 
     public void indexIterator(Session session, FDBStoreData storeData,
-                              boolean key, boolean inclusive, boolean reverse,
+                              boolean key, boolean startInclusive, boolean endInclusive, boolean reverse,
                               FDBScanTransactionOptions transactionOptions) {
         storeData.storageDescription.indexIterator(this, session, storeData,
-                                                   key, inclusive, reverse,
+                                                   key, startInclusive, endInclusive, reverse,
                                                    transactionOptions);
     }
 

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/FDBStoreData.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/FDBStoreData.java
@@ -42,6 +42,7 @@ public class FDBStoreData {
     // What way, if any, persistitKey has been nudged
     public NudgeDir nudgeDir;
     public Key endKey;
+    public boolean exactEnd;
     
     public FDBStoreData(Session session, FDBStorageDescription storageDescription, Key persistitKey, Key endKey) {
         this.storageDescription = storageDescription;

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/format/FDBStorageDescription.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/format/FDBStorageDescription.java
@@ -313,8 +313,7 @@ public class FDBStorageDescription extends StoreStorageDescription<FDBStore,FDBS
                 } else {
                     ksLeft = KeySelector.firstGreaterThan(prefixBytes);
                 }
-                //ksRight = KeySelector.lastLessThan(packKey(storeData));
-                ksRight = KeySelector.firstGreaterThan(packKey(storeData));
+                ksRight = KeySelector.firstGreaterOrEqual(packKey(storeData));
             } 
             else {
                 ksLeft = KeySelector.firstGreaterThan(packKey(storeData));

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/statistics/FDBStoreIndexStatistics.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/statistics/FDBStoreIndexStatistics.java
@@ -132,7 +132,7 @@ public class FDBStoreIndexStatistics extends AbstractStoreIndexStatistics<FDBSto
         visitor.init(bucketCount);
         FDBStoreData storeData = getStore().createStoreData(session, index);
         // Whole index, forward.
-        getStore().indexIterator(session, storeData, false, false, false,
+        getStore().indexIterator(session, storeData, false, false, true, false,
                                  transactionOptions);
         while(storeData.next()) {
             if (++skippedSamples < sampleRate)

--- a/fdb-sql-layer-core/src/test/java/com/foundationdb/server/test/it/qp/Except_OrderedIT.java
+++ b/fdb-sql-layer-core/src/test/java/com/foundationdb/server/test/it/qp/Except_OrderedIT.java
@@ -365,7 +365,7 @@ public class Except_OrderedIT extends OperatorITBase
     }
 
     @Test
-    public void testDisjoint()
+    public void testDisjoint_asc_duplicates()
     {
         Operator plan = exceptPlan( uXIndexRowType,tXIndexRowType, true, false);
         Row[] expected = new Row[] {
@@ -377,9 +377,13 @@ public class Except_OrderedIT extends OperatorITBase
                 row(uRowType, 9L, 1005L),
         };
         compareRows(expected, cursor(plan, queryContext, queryBindings));
+    }
+    @Test
+    public void testDisjoint_desc_duplicates()
+    {
 
-        plan = exceptPlan( uXIndexRowType,tXIndexRowType, false, false);
-        expected = new Row[] {
+        Operator plan = exceptPlan( uXIndexRowType,tXIndexRowType, false, false);
+        Row[] expected = new Row[] {
                 row(uRowType, 9L, 1005L),
                 row(uRowType, 9L, 1004L),
                 row(uRowType, 8L, 1003L),
@@ -388,8 +392,13 @@ public class Except_OrderedIT extends OperatorITBase
                 row(uRowType, 1L, 1000L),
         };
         compareRows(expected, cursor(plan, queryContext, queryBindings));
-        plan = exceptPlan( uXIndexRowType,tXIndexRowType, true, true);
-        expected = new Row[] {
+    }
+
+    @Test
+    public void testDisjoint_asc_noDulicates()
+    {
+        Operator plan = exceptPlan( uXIndexRowType,tXIndexRowType, true, true);
+        Row[] expected = new Row[] {
                 row(uRowType, 1L, 1000L),
                 row(uRowType, 2L, 1001L),
                 row(uRowType, 5L, 1002L),
@@ -397,9 +406,13 @@ public class Except_OrderedIT extends OperatorITBase
                 row(uRowType, 9L, 1004L),
         };
         compareRows(expected, cursor(plan, queryContext, queryBindings));
-
-        plan = exceptPlan( uXIndexRowType,tXIndexRowType, false, true);
-        expected = new Row[] {
+    }
+    
+    @Test
+    public void testDisjoint_desc_noDulicates()
+    {
+        Operator plan = exceptPlan( uXIndexRowType,tXIndexRowType, false, true);
+        Row[] expected = new Row[] {
                 row(uRowType, 9L, 1005L),
                 row(uRowType, 8L, 1003L),
                 row(uRowType, 5L, 1002L),

--- a/fdb-sql-layer-core/src/test/java/com/foundationdb/server/test/it/qp/IndexScanBoundedPKIT.java
+++ b/fdb-sql-layer-core/src/test/java/com/foundationdb/server/test/it/qp/IndexScanBoundedPKIT.java
@@ -1,0 +1,352 @@
+/**
+ * Copyright (C) 2009-2015 FoundationDB, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.foundationdb.server.test.it.qp;
+
+import com.foundationdb.qp.expression.IndexBound;
+import com.foundationdb.qp.expression.IndexKeyRange;
+import com.foundationdb.qp.expression.RowBasedUnboundExpressions;
+import com.foundationdb.qp.expression.UnboundExpressions;
+import com.foundationdb.qp.operator.API;
+import com.foundationdb.qp.operator.Operator;
+import com.foundationdb.qp.row.Row;
+import com.foundationdb.qp.rowtype.IndexRowType;
+import com.foundationdb.qp.rowtype.RowType;
+import com.foundationdb.qp.rowtype.Schema;
+import com.foundationdb.server.api.dml.SetColumnSelector;
+import com.foundationdb.server.types.texpressions.TNullExpression;
+import com.foundationdb.server.types.texpressions.TPreparedExpression;
+import com.foundationdb.server.types.texpressions.TPreparedLiteral;
+import com.foundationdb.server.types.value.Value;
+import com.foundationdb.server.types.value.ValueSources;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static com.foundationdb.qp.operator.API.cursor;
+import static com.foundationdb.qp.operator.API.indexScan_Default;
+import static com.foundationdb.server.test.ExpressionGenerators.field;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/*
+ * This test covers bounded index scans with combinations of the following variations:
+ * - ascending/descending/mixed order
+ * - inclusive/exclusive/semi-bounded
+ * - bound is present/missing
+ */
+
+public class IndexScanBoundedPKIT extends OperatorITBase
+{
+    @Override
+    protected void setupCreateSchema()
+    {
+        t = createTable(
+            "schema", "t",
+            "id int not null primary key",
+            "a int",
+            "b int",
+            "c int");
+        createIndex("schema", "t", "a", "a", "b", "c", "id");
+    }
+
+    @Override
+    protected void setupPostCreateSchema()
+    {
+        tRowType = schema.tableRowType(table(t));
+        pkRowType = indexType(t, "id");
+        idxRowType = indexType(t, "a", "b", "c", "id");
+        db = new Row[]{
+            // No nulls
+            row(t, 1000L, 1L, 11L, 111L),
+            row(t, 1001L, 1L, 11L, 115L),
+            row(t, 1002L, 1L, 15L, 151L),
+            row(t, 1003L, 1L, 15L, 155L),
+            row(t, 1004L, 5L, 51L, 511L),
+            row(t, 1005L, 5L, 51L, 515L),
+            row(t, 1006L, 5L, 55L, 551L),
+            row(t, 1007L, 5L, 55L, 555L),
+        };
+        queryContext = queryContext(adapter);
+        queryBindings = queryContext.createBindings();
+        use(db);
+    }
+
+    // Test name: test_AB_CD
+    // A: Lo Inclusive/Exclusive
+    // B: Lo Bound is present/missing
+    // C: Hi Inclusive/Exclusive
+    // D: Hi Bound is present/missing
+    // AB/CD combinations are not tested exhaustively because processing at
+    // start and end of scan are independent.
+
+    @Test
+    public void test_IP_IP_A()
+    {
+        // A
+        test(pkRange(INCLUSIVE, 1, INCLUSIVE, 5),
+             ordering(ASC),
+             1000, 1001, 1002, 1003, 1004, 1005, 1006, 1007);
+    }
+
+    @Test
+    public void test_IP_IP_D()
+    {
+        // D
+        test(pkRange(INCLUSIVE, 1,INCLUSIVE, 5),
+             ordering(DESC),
+             1007, 1006, 1005, 1004, 1003, 1002, 1001, 1000);
+    }
+
+    
+    @Test
+    public void test_IM_IM_A()
+    {
+        // A
+        test(pkRange(INCLUSIVE, 0, INCLUSIVE, 6),
+             ordering(ASC),
+             1000, 1001, 1002, 1003, 1004, 1005, 1006, 1007);
+    }
+    @Test
+    public void test_IM_IM_D() 
+    {
+        // D
+        test(pkRange(INCLUSIVE, 0, INCLUSIVE, 6),
+             ordering(DESC),
+             1007, 1006, 1005, 1004, 1003, 1002, 1001, 1000);
+    }
+    @Test
+    public void test_EP_EP_A()
+    {
+        // A
+        test(pkRange(EXCLUSIVE, 1, EXCLUSIVE, 5),
+             ordering(ASC));
+    }
+    @Test
+    public void test_EP_EP_D()
+    {
+        // D
+        test(pkRange(EXCLUSIVE, 1,EXCLUSIVE, 5),
+             ordering(DESC));
+    }
+    
+    @Test
+    public void test_EM_EM_A()
+    {
+        // A
+        test(pkRange(EXCLUSIVE, 0, EXCLUSIVE, 6),
+             ordering(ASC),
+             1000, 1001, 1002, 1003, 1004, 1005, 1006, 1007);
+    }
+    @Test
+    public void test_EM_EM_D()
+    {
+        // D
+        test(pkRange(EXCLUSIVE, 0, EXCLUSIVE, 6),
+             ordering(DESC),
+             1007, 1006, 1005, 1004, 1003, 1002, 1001, 1000);
+    }
+
+
+    // Test half-bounded ranges
+
+    @Test
+    public void testBoundedLeftInclusive_A()
+    {
+        // A
+        test(pkRange(INCLUSIVE, 1, EXCLUSIVE, null),
+             ordering(ASC),
+             1000, 1001, 1002, 1003, 1004, 1005, 1006, 1007);
+    }
+    @Test
+    public void testBoundedLeftInclusive_D()
+    {
+        // D
+        test(pkRange(INCLUSIVE, 1, EXCLUSIVE, null),
+             ordering(DESC),
+             1007, 1006, 1005, 1004, 1003, 1002, 1001, 1000);
+    }
+
+    @Test
+    public void testBoundedLeftExclusive_A()
+    {
+        // A
+        test(pkRange(EXCLUSIVE, 3, EXCLUSIVE, null),
+             ordering(ASC),
+             1004, 1005, 1006, 1007);
+    }
+    @Test
+    public void testBoundedLeftExclusive_D()
+    {
+        // D
+        test(pkRange(EXCLUSIVE, 3, EXCLUSIVE, null),
+             ordering(DESC),
+             1007, 1006, 1005, 1004);
+    }
+
+    @Test
+    public void testBoundedRightInclusive_A()
+    {
+        // A
+        test(pkRange(EXCLUSIVE, null, INCLUSIVE, 5),
+             ordering(ASC),
+             1000, 1001, 1002, 1003, 1004, 1005, 1006, 1007);
+    }
+    @Test
+    public void testBoundedRightInclusive_D()
+    {
+        // D
+        test(pkRange(EXCLUSIVE, null, INCLUSIVE, 5),
+             ordering(DESC),
+             1007, 1006, 1005, 1004, 1003, 1002, 1001, 1000);
+    }
+
+    @Test
+    public void testBoundedRightExclusive_A()
+    {
+        // A
+        test(pkRange(EXCLUSIVE, null,EXCLUSIVE, 8),
+             ordering(ASC),
+             1000, 1001, 1002, 1003, 1004, 1005, 1006, 1007);
+    }
+    @Test
+    public void testBoundedRightExclusive_D()
+    {
+        // D
+        test(pkRange(EXCLUSIVE, null, EXCLUSIVE, 8),
+             ordering(DESC),
+             1007, 1006, 1005, 1004, 1003, 1002, 1001, 1000);
+    }
+
+    // case 2: > null <= null
+    @Test(expected=IllegalArgumentException.class)
+    public void leftExclusiveNullRightInclusiveNull() {
+        testEmptySet(pkRange(EXCLUSIVE, null, INCLUSIVE, null),
+             ordering(ASC));
+    }
+
+    // case 6: > non-null, <= null
+    @Test(expected=IllegalArgumentException.class)
+    public void leftExclusiveNonNullRightInclusiveNull() {
+        testEmptySet(pkRange(EXCLUSIVE, 1000, INCLUSIVE, null),
+             ordering(ASC));
+    }
+
+    // case 10: >= null, <= null
+    @Test
+    public void leftInclusiveNullRightInclusiveNull() {
+        Row row = row(t, 2000L, null, 11L, 111L);
+        writeRows(row);
+        db = Arrays.copyOf(db, db.length + 1);
+        db[db.length -1] = row;
+        test(pkRange(INCLUSIVE, null, INCLUSIVE, null),
+             ordering(ASC),
+             2000);
+    }
+
+    // case 14: >= non-null, <= null
+    @Test(expected=IllegalArgumentException.class)
+    public void leftInclusiveNonNullRightInclusiveNull() {
+        testEmptySet(pkRange(INCLUSIVE, 1000, INCLUSIVE, null),
+             ordering(ASC));
+    }
+
+    // For use by this class
+
+    private void test(IndexKeyRange keyRange, API.Ordering ordering, int ... expectedIds)
+    {
+        Operator plan = indexScan_Default(idxRowType, keyRange, ordering);
+        Row[] expected = new Row[expectedIds.length];
+        for (int i = 0; i < expectedIds.length; i++) {
+            int id = expectedIds[i];
+            expected[i] = dbRow(id);
+        }
+        compareRows(expected, cursor(plan, queryContext, queryBindings));
+    }
+    
+    private void testEmptySet (IndexKeyRange keyRange, API.Ordering ordering) 
+    {
+        Operator plan = indexScan_Default(idxRowType, keyRange, ordering);
+        Row[] expected = new Row[0];
+        compareRows(expected, cursor(plan, queryContext, queryBindings));
+    }
+
+    private void dump(IndexKeyRange keyRange, API.Ordering ordering, int ... expectedIds)
+    {
+        Operator plan = indexScan_Default(idxRowType, keyRange, ordering);
+        dumpToAssertion(plan);
+    }
+
+    private UnboundExpressions pkExprRow (Integer a) {
+        List<TPreparedExpression> pExprs = new ArrayList<>(1);
+        if (a == null) {
+            pExprs.add(new TNullExpression(pkRowType.typeAt(0)));
+        } else {
+            pExprs.add(new TPreparedLiteral(new Value(pkRowType.typeAt(0), a)));
+        }
+        return  new RowBasedUnboundExpressions(pkRowType, pExprs);
+    }
+    
+    private IndexKeyRange pkRange(boolean loInclusive, Integer aLo, 
+                                  boolean hiInclusive, Integer aHi) 
+    {
+        IndexBound lo = new IndexBound(pkExprRow(aLo), new SetColumnSelector(0));
+        IndexBound hi = new IndexBound(pkExprRow(aHi), new SetColumnSelector(0));
+        return IndexKeyRange.bounded(pkRowType, lo, loInclusive, hi, hiInclusive);
+    }
+    
+    private API.Ordering ordering(boolean direction) {
+        API.Ordering ordering = API.ordering();
+        ordering.append(field(pkRowType, 0), direction);
+        return ordering;
+    }
+
+    private Row dbRow(long id)
+    {
+        for (Row newRow : db) {
+            if (ValueSources.getLong(newRow.value(0)) == id) {
+                return row(idxRowType,
+                           ValueSources.toObject(newRow.value(1)),
+                           ValueSources.toObject(newRow.value(2)),
+                           ValueSources.toObject(newRow.value(3)),
+                           ValueSources.toObject(newRow.value(0)));
+            }
+        }
+        fail();
+        return null;
+    }
+
+    // Positions of fields within the index row
+    private static final int A = 0;
+    private static final int B = 1;
+    private static final int C = 2;
+    private static final int ID = 3;
+    private static final boolean ASC = true;
+    private static final boolean DESC = false;
+    private static final boolean EXCLUSIVE = false;
+    private static final boolean INCLUSIVE = true;
+    private static final Integer UNSPECIFIED = new Integer(Integer.MIN_VALUE); // Relying on == comparisons
+
+    private int t;
+    private RowType tRowType;
+    private IndexRowType idxRowType;
+    private IndexRowType pkRowType;
+}

--- a/fdb-sql-layer-core/src/test/resources/log4j.properties
+++ b/fdb-sql-layer-core/src/test/resources/log4j.properties
@@ -16,6 +16,7 @@
 #
 
 log4j.rootCategory=ERROR,console
+#log4j.category.com.foundationdb.server.store.format.FDBStorageDescription=TRACE,console
 
 # Set to be a ConsoleAppender (writes to system console).
 log4j.appender.console=org.apache.log4j.ConsoleAppender

--- a/fdb-sql-layer-core/src/test/resources/log4j.properties
+++ b/fdb-sql-layer-core/src/test/resources/log4j.properties
@@ -16,7 +16,6 @@
 #
 
 log4j.rootCategory=ERROR,console
-#log4j.category.com.foundationdb.server.store.format.FDBStorageDescription=TRACE,console
 
 # Set to be a ConsoleAppender (writes to system console).
 log4j.appender.console=org.apache.log4j.ConsoleAppender


### PR DESCRIPTION
Add a endExclusive flag for the end of range on a key selector. By setting this correctly the FDB K/V Store returns only exactly the rows required by the index scan. This is a performance enhancement (fewer rows from the storage layer). 

Add one new test to verify the variations on a test which was failing elsewhere. So make sure we catch all the variations as well, as a specific test. 

All of the tests have been run with the two asserts in `IndexCursorUnidirectional.java` enabled and they all pass (including the new one). But they need to be disabled in the production code because they won't pass with the Persistit storage layer enabled. 