### PR TITLE
Add external config path in test policy

### DIFF
--- a/fdb-sql-layer-common/test/resources/tests.policy
+++ b/fdb-sql-layer-common/test/resources/tests.policy
@@ -21,6 +21,11 @@ grant codeBase "file:${mvn.settings.localRepository}/-" {
   permission java.util.PropertyPermission "*", "read";
 };
 
+/* Externally configurable path. For e.g. IDE root dir. */
+ grant codeBase "file:${fdbsql.test.extra_policy_path}/-" {
+   permission java.security.AllPermission;
+ };
+
 grant {
   permission java.io.FilePermission "${java.io.tmpdir}${/}-", "read,write,delete";
   permission java.io.FilePermission "${mvn.main.basedir}/*/target/surefire/-", "read,write";


### PR DESCRIPTION
IntelliJ, at least, is happy with this plus `-Dfdbsql.test.extra_policy_path="/Applications/IntelliJ IDEA 14 CE.app"` in the test config.