### PR TITLE
Add memory storage implementation

### DIFF
--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/qp/storeadapter/MemoryAdapter.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/qp/storeadapter/MemoryAdapter.java
@@ -1,0 +1,168 @@
+/**
+ * Copyright (C) 2009-2015 FoundationDB, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.foundationdb.qp.storeadapter;
+
+import com.foundationdb.ais.model.AkibanInformationSchema;
+import com.foundationdb.ais.model.Group;
+import com.foundationdb.ais.model.GroupIndex;
+import com.foundationdb.ais.model.Sequence;
+import com.foundationdb.ais.model.TableIndex;
+import com.foundationdb.qp.expression.IndexKeyRange;
+import com.foundationdb.qp.operator.API.Ordering;
+import com.foundationdb.qp.operator.API.SortOption;
+import com.foundationdb.qp.operator.GroupCursor;
+import com.foundationdb.qp.operator.IndexScanSelector;
+import com.foundationdb.qp.operator.QueryBindings;
+import com.foundationdb.qp.operator.QueryContext;
+import com.foundationdb.qp.operator.RowCursor;
+import com.foundationdb.qp.operator.StoreAdapter;
+import com.foundationdb.qp.row.IndexRow;
+import com.foundationdb.qp.row.Row;
+import com.foundationdb.qp.rowtype.IndexRowType;
+import com.foundationdb.qp.rowtype.RowType;
+import com.foundationdb.qp.storeadapter.indexcursor.IterationHelper;
+import com.foundationdb.qp.storeadapter.indexcursor.MergeJoinSorter;
+import com.foundationdb.qp.storeadapter.indexrow.IndexRowPool;
+import com.foundationdb.qp.storeadapter.indexrow.MemoryIndexRow;
+import com.foundationdb.server.error.DuplicateKeyException;
+import com.foundationdb.server.service.config.ConfigurationService;
+import com.foundationdb.server.service.session.Session;
+import com.foundationdb.server.service.tree.KeyCreator;
+import com.foundationdb.server.store.MemoryStore;
+import com.foundationdb.util.tap.InOutTap;
+
+import java.util.Collection;
+
+public class MemoryAdapter extends StoreAdapter
+{
+    private static final IndexRowPool indexRowPool = new IndexRowPool();
+
+    private final MemoryStore store;
+
+    public MemoryAdapter(Session session, ConfigurationService config, MemoryStore store) {
+        super(session, config);
+        this.store = store;
+    }
+
+
+    @Override
+    public GroupCursor newGroupCursor(Group group) {
+        return new MemoryGroupCursor(this, group);
+    }
+
+    @Override
+    public RowCursor newIndexCursor(QueryContext context,
+                                    IndexRowType rowType,
+                                    IndexKeyRange keyRange,
+                                    Ordering ordering,
+                                    IndexScanSelector scanSelector,
+                                    boolean openAllSubCursors) {
+        return new PersistitIndexCursor(context,
+                                        rowType,
+                                        keyRange,
+                                        ordering,
+                                        scanSelector,
+                                        openAllSubCursors);
+    }
+
+    @Override
+    public void updateRow(Row oldRow, Row newRow) {
+        try {
+            store.updateRow(getSession(), oldRow, newRow);
+        } catch(DuplicateKeyException e) {
+            store.setRollbackPending(getSession());
+            throw e;
+        }
+    }
+
+    @Override
+    public void writeRow(Row newRow, Collection<TableIndex> tableIndexes, Collection<GroupIndex> groupIndexes) {
+        try {
+            store.writeRow(getSession(), newRow, tableIndexes, groupIndexes);
+        } catch(DuplicateKeyException e) {
+            store.setRollbackPending(getSession());
+            throw e;
+        }
+    }
+
+    @Override
+    public void deleteRow(Row oldRow, boolean cascadeDelete) {
+        try {
+            store.deleteRow(getSession(), oldRow, cascadeDelete);
+        } catch(DuplicateKeyException e) {
+            store.setRollbackPending(getSession());
+            throw e;
+        }
+    }
+
+    @Override
+    public Sorter createSorter(QueryContext context,
+                               QueryBindings bindings,
+                               RowCursor input,
+                               RowType rowType,
+                               Ordering ordering,
+                               SortOption sortOption,
+                               InOutTap loadTap) {
+        return new MergeJoinSorter(context, bindings, input, rowType, ordering, sortOption, loadTap);
+    }
+
+    @Override
+    public long sequenceNextValue(Sequence sequence) {
+        return store.nextSequenceValue(getSession(), sequence);
+    }
+
+    @Override
+    public long sequenceCurrentValue(Sequence sequence) {
+        return store.curSequenceValue(getSession(), sequence);
+    }
+
+    @Override
+    public IndexRow newIndexRow(IndexRowType indexRowType) {
+        return new MemoryIndexRow(getUnderlyingStore(), indexRowType);
+    }
+
+    @Override
+    public IndexRow takeIndexRow(IndexRowType indexRowType) {
+        return indexRowPool.takeIndexRow(this, indexRowType);
+    }
+
+    @Override
+    public void returnIndexRow(IndexRow indexRow) {
+        indexRowPool.returnIndexRow(this, indexRow.rowType(), indexRow);
+    }
+
+    @Override
+    public IterationHelper createIterationHelper(IndexRowType indexRowType) {
+        return new MemoryIterationHelper(this, indexRowType);
+    }
+
+    @Override
+    public KeyCreator getKeyCreator() {
+        return store;
+    }
+
+    @Override
+    protected MemoryStore getUnderlyingStore() {
+        return store;
+    }
+
+    @Override
+    public AkibanInformationSchema getAIS() {
+        return store.getAIS(getSession());
+    }
+}

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/qp/storeadapter/MemoryGroupCursor.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/qp/storeadapter/MemoryGroupCursor.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright (C) 2009-2015 FoundationDB, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.foundationdb.qp.storeadapter;
+
+import com.foundationdb.ais.model.Group;
+import com.foundationdb.qp.operator.CursorLifecycle;
+import com.foundationdb.qp.operator.GroupCursor;
+import com.foundationdb.qp.operator.RowCursorImpl;
+import com.foundationdb.qp.row.HKey;
+import com.foundationdb.qp.row.Row;
+import com.foundationdb.qp.rowtype.Schema;
+import com.foundationdb.qp.util.SchemaCache;
+import com.foundationdb.server.store.MemoryStoreData;
+
+public class MemoryGroupCursor extends RowCursorImpl implements GroupCursor
+{
+    private final MemoryAdapter adapter;
+    private final MemoryStoreData storeData;
+    private final Schema schema;
+    private HKey hKey;
+    private boolean hKeyDeep;
+    private GroupScan groupScan;
+
+    public MemoryGroupCursor(MemoryAdapter adapter, Group group) {
+        this.adapter = adapter;
+        this.storeData = adapter.getUnderlyingStore()
+                                .createStoreData(adapter.getSession(), group);
+        this.schema = SchemaCache.globalSchema(group.getAIS());
+    }
+
+    @Override
+    public void open() {
+        super.open();
+        if(hKey == null) {
+            groupScan = new FullScan();
+        } else if(hKeyDeep) {
+            groupScan = new HKeyAndDescendantScan(hKey);
+        } else {
+            groupScan = new HKeyWithoutDescendantScan(hKey);
+        }
+    }
+
+    @Override
+    public MemoryGroupRow next() {
+        CursorLifecycle.checkIdleOrActive(this);
+        boolean next = isActive();
+        MemoryGroupRow row = null;
+        if(next) {
+            groupScan.advance();
+            next = isActive();
+            if (next) {
+                Row tempRow = adapter.getUnderlyingStore().expandGroupData(adapter.getSession(), storeData, schema);
+                row = new MemoryGroupRow(adapter.getKeyCreator(), tempRow, storeData.persistitKey);
+            }
+        }
+        return row;
+    }
+
+    @Override
+    public void close() {
+        groupScan = null;
+        super.close();
+    }
+
+    @Override
+    public void rebind(HKey hKey, boolean deep) {
+        CursorLifecycle.checkClosed(this);
+        this.hKey = hKey;
+        this.hKeyDeep = deep;
+    }
+
+    //
+    // Internal
+    //
+
+    private abstract class GroupScan {
+        public void advance() {
+            if(!storeData.next()) {
+                setIdle();
+            }
+        }
+    }
+
+    private class FullScan extends GroupScan
+    {
+        public FullScan() {
+            adapter.getUnderlyingStore().groupIterator(adapter.getSession(), storeData);
+        }
+    }
+
+    private class HKeyAndDescendantScan extends GroupScan
+    {
+        public HKeyAndDescendantScan(HKey hKey) {
+            hKey.copyTo(storeData.persistitKey.clear());
+            adapter.getUnderlyingStore().groupKeyAndDescendantsIterator(adapter.getSession(), storeData);
+        }
+    }
+
+    private class HKeyWithoutDescendantScan extends GroupScan
+    {
+        boolean first = true;
+
+        @Override
+        public void advance()
+        {
+            if(first) {
+                super.advance();
+                first = false;
+            } else {
+                setIdle();
+            }
+        }
+
+        public HKeyWithoutDescendantScan(HKey hKey)
+        {
+            storeData.persistitKey.clear();
+            hKey.copyTo(storeData.persistitKey);
+            adapter.getUnderlyingStore().groupKeyIterator(adapter.getSession(), storeData);
+        }
+    }
+}

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/qp/storeadapter/MemoryGroupRow.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/qp/storeadapter/MemoryGroupRow.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (C) 2009-2015 FoundationDB, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.foundationdb.qp.storeadapter;
+
+import com.foundationdb.ais.model.Table;
+import com.foundationdb.qp.row.AbstractRow;
+import com.foundationdb.qp.row.HKey;
+import com.foundationdb.qp.row.Row;
+import com.foundationdb.qp.rowtype.RowType;
+import com.foundationdb.server.service.tree.KeyCreator;
+import com.foundationdb.server.types.value.ValueSource;
+import com.persistit.Key;
+
+public class MemoryGroupRow extends AbstractRow
+{
+    private final KeyCreator keyCreator;
+    private final Row underlying;
+    private final HKey currentHKey;
+
+    public MemoryGroupRow(KeyCreator keyCreator, Row abstractRow, Key key) {
+        this.keyCreator = keyCreator;
+        this.underlying = abstractRow;
+        this.currentHKey = keyCreator.newHKey(rowType().table().hKey());
+        if(key != null) {
+            currentHKey.copyFrom(key);
+        }
+    }
+
+    @Override
+    public HKey hKey()  {
+        return currentHKey;
+    }
+
+    @Override
+    public HKey ancestorHKey(Table table)  {
+        HKey ancestorHKey = keyCreator.newHKey(table.hKey());
+        currentHKey.copyTo(ancestorHKey);
+        ancestorHKey.useSegments(table.getDepth() + 1);
+        return ancestorHKey;
+    }
+
+    @Override
+    public boolean containsRealRowOf(Table table) {
+        return rowType().table() == table;
+    }
+
+    @Override
+    public boolean isBindingsSensitive() {
+        return false;
+    }
+
+    @Override
+    public RowType rowType() {
+        return underlying.rowType();
+    }
+
+    @Override
+    protected ValueSource uncheckedValue(int i) {
+        return underlying.value(i);
+    }
+}
+

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/qp/storeadapter/MemoryIterationHelper.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/qp/storeadapter/MemoryIterationHelper.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright (C) 2009-2015 FoundationDB, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.foundationdb.qp.storeadapter;
+
+import com.foundationdb.qp.row.IndexRow;
+import com.foundationdb.qp.storeadapter.indexcursor.IterationHelper;
+import com.foundationdb.qp.row.Row;
+import com.foundationdb.qp.rowtype.IndexRowType;
+import com.foundationdb.server.store.MemoryStore;
+import com.foundationdb.server.store.MemoryStoreData;
+import com.persistit.Key;
+import com.persistit.Key.Direction;
+import com.persistit.Persistit;
+import com.persistit.Value;
+
+import static com.persistit.Key.Direction.GT;
+import static com.persistit.Key.Direction.GTEQ;
+import static com.persistit.Key.Direction.LT;
+import static com.persistit.Key.Direction.LTEQ;
+
+public class MemoryIterationHelper implements IterationHelper
+{
+    private final MemoryAdapter adapter;
+    private final IndexRowType rowType;
+    private final MemoryStoreData storeData;
+    // Initialized upon traversal
+    private long lastKeyGen;
+    private Direction itDir;
+
+    public MemoryIterationHelper(MemoryAdapter adapter, IndexRowType indexRowType) {
+        this.adapter = adapter;
+        this.rowType = indexRowType.physicalRowType();
+        this.storeData = adapter.getUnderlyingStore().createStoreData(adapter.getSession(), rowType.index());
+        this.storeData.persistitValue = new Value((Persistit)null);
+    }
+
+    //
+    // IterationHelper
+    //
+
+    @Override
+    public Key key() {
+        return storeData.persistitKey;
+    }
+
+    @Override
+    public Key endKey() {
+        return storeData.endKey;
+    }
+
+    @Override
+    public void clear() {
+        storeData.persistitKey.clear();
+        storeData.persistitValue.clear();
+        lastKeyGen = -1;
+        itDir = null;
+    }
+
+    @Override
+    public void openIteration() {
+        // None, iterator created on demand
+    }
+
+    @Override
+    public void closeIteration() {
+        //adapter.returnIndexRow(row);
+    }
+
+    @Override
+    public Row row() {
+        assert (storeData.rawKey != null) : "Called for chopped key (or before iterating)"; // See advanceLogical() for former
+        IndexRow row = adapter.takeIndexRow(rowType);
+        // updateKey() called from advance
+        MemoryStore.unpackValue(storeData);
+        row.copyFrom(storeData.persistitKey, storeData.persistitValue);
+        return row;
+    }
+
+    @Override
+    public boolean traverse(Direction dir) {
+        checkIterator(dir, true);
+        return advance();
+    }
+
+    @Override
+    public void preload(Direction dir, boolean endInclusive) {
+        checkIterator(dir, endInclusive);
+    }
+
+    //
+    // Internal
+    //
+    /** Advance iterator with pure physical (i.e. key order) traversal. */
+    private boolean advance() {
+        if(storeData.next()) {
+            MemoryStore.unpackKey(storeData);
+            lastKeyGen = storeData.persistitKey.getGeneration();
+            return true;
+        }
+        return false;
+    }
+
+    /** Check current iterator matches direction and recreate if not. */
+    private void checkIterator(Direction dir, boolean endInclusive) {
+        final boolean keyGenMatches = (lastKeyGen == storeData.persistitKey.getGeneration());
+        if((itDir != dir) || !keyGenMatches) {
+            // If the last key we returned hasn't changed and moving in the same direction, new iterator isn't needed.
+            if(keyGenMatches) {
+                if((itDir == GTEQ && dir == GT) || (itDir == LTEQ && dir == LT)) {
+                    itDir = dir;
+                    return;
+                }
+            }
+            final boolean reverse = (dir == LT) || (dir == LTEQ);
+            // Note: storeData.persistitKey is already adjusted appropriately for endInclusive.
+            //       indexIterator() API will need to change when Key is no longer used.
+            adapter.getUnderlyingStore().indexIterator(adapter.getSession(), storeData, reverse);
+            lastKeyGen = storeData.persistitKey.getGeneration();
+            itDir = dir;
+        }
+    }
+}

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/qp/storeadapter/indexrow/MemoryIndexRow.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/qp/storeadapter/indexrow/MemoryIndexRow.java
@@ -1,0 +1,325 @@
+/**
+ * Copyright (C) 2009-2015 FoundationDB, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.foundationdb.qp.storeadapter.indexrow;
+
+import static java.lang.Math.min;
+
+import com.foundationdb.ais.model.GroupIndex;
+import com.foundationdb.ais.model.TableIndex;
+import com.foundationdb.ais.model.Index;
+import com.foundationdb.ais.model.IndexToHKey;
+import com.foundationdb.ais.model.Table;
+import com.foundationdb.qp.row.HKey;
+import com.foundationdb.qp.row.IndexRow;
+import com.foundationdb.qp.row.ValuesHKey;
+import com.foundationdb.qp.rowtype.IndexRowType;
+import com.foundationdb.qp.storeadapter.indexcursor.SortKeyAdapter;
+import com.foundationdb.qp.storeadapter.indexcursor.SortKeyTarget;
+import com.foundationdb.qp.storeadapter.indexcursor.ValueSortKeyAdapter;
+import com.foundationdb.qp.util.PersistitKey;
+import com.foundationdb.server.PersistitKeyValueSource;
+import com.foundationdb.server.service.tree.KeyCreator;
+import com.foundationdb.server.types.TInstance;
+import com.foundationdb.server.types.texpressions.TPreparedExpression;
+import com.foundationdb.server.types.value.ValueSource;
+import com.foundationdb.util.ArgumentValidation;
+import com.persistit.Key;
+import com.persistit.Value;
+
+public class MemoryIndexRow extends IndexRow
+{
+    private final SortKeyAdapter<ValueSource, TPreparedExpression> SORT_KEY_ADAPTER = ValueSortKeyAdapter.INSTANCE;
+
+    private Index index;
+    private Key iKey;
+    private Value iValue;
+    private final IndexRowType indexRowType;
+    private long tableBitmap;
+    private SortKeyTarget pKeyTarget;
+
+    private int pKeyFields;
+
+    private final TInstance[] types;
+    private final KeyCreator keyCreator;
+    private HKey leafTableHKey;
+    private int zPosition;
+
+    public MemoryIndexRow(KeyCreator keyCreator) {
+        ArgumentValidation.notNull("keyCreator", keyCreator);
+        this.keyCreator = keyCreator;
+        this.indexRowType = null;
+        this.types = null;
+    }
+
+    public MemoryIndexRow(KeyCreator adapter, IndexRowType indexRowType) {
+        ArgumentValidation.notNull("keyCreator", adapter);
+        this.keyCreator = adapter;
+        this.iKey = adapter.createKey();
+        this.indexRowType = indexRowType;
+        this.index = indexRowType.index();
+        resetForWrite(index, iKey);
+        this.types = index.types();
+    }
+
+    //
+    // IndexRow
+    //
+
+    @Override
+    public IndexRowType rowType() {
+        return indexRowType;
+    }
+
+    @Override
+    protected ValueSource uncheckedValue(int i) {
+        PersistitKeyValueSource source = new PersistitKeyValueSource(types[i]);
+        source.attach(iKey, i, types[i]);
+        return source;
+    }
+
+    @Override
+    public HKey hKey() {
+        assert this.leafTableHKey != null;
+        return this.leafTableHKey;
+    }
+
+    @Override
+    public HKey ancestorHKey(Table table) {
+        HKey ancestorHKey;
+
+        IndexToHKey indexToHKey;
+        if(index.isGroupIndex()) {
+            ancestorHKey = keyCreator.newHKey(table.hKey());
+            indexToHKey = ((GroupIndex)index).indexToHKey(table.getDepth());
+        } else {
+            ancestorHKey = keyCreator.newHKey(index.leafMostTable().hKey());
+            indexToHKey = ((TableIndex)index).indexToHKey();
+        }
+
+        //Short circuit if the key is empty.
+        if(this.keyEmpty()) {
+            this.leafTableHKey = ancestorHKey;
+            return ancestorHKey;
+        }
+        int segment = 0;
+        int columns = 0;
+        ValuesHKey ancestor = (ValuesHKey)ancestorHKey;
+        for(int i = 0; i < indexToHKey.getLength(); i++) {
+            if(indexToHKey.isOrdinal(i)) {
+                // Do nothing, the ValuesHKey should have the correct ordinals
+                // built from the metadata.
+                assert indexToHKey.getOrdinal(i) == ancestor.ordinals()[segment];
+                segment++;
+            } else {
+                int indexField = indexToHKey.getIndexRowPosition(i);
+                if(index.isSpatial() && indexField > index.firstSpatialArgument()) {
+                    // A spatial index has a single key column (the z-value), representing the declared spatial key columns.
+                    indexField -= index.spatialColumns() - 1;
+                }
+                ancestor.copyValueTo(this.value(indexField), columns++);
+            }
+        }
+        // Copy the leaf table HKey for later use.
+        // Return the correct (shortened) HKey for others to use.
+        if(index.isTableIndex() && index.leafMostTable() != table) {
+            this.leafTableHKey = ancestorHKey;
+            ancestorHKey = keyCreator.newHKey(table.hKey());
+            this.leafTableHKey.copyTo(ancestorHKey);
+            ancestorHKey.useSegments(table.getDepth() + 1);
+        }
+        return ancestorHKey;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <S> void append(S source, TInstance type) {
+        pKeyTarget.append(source, type);
+    }
+
+    @Override
+    public void append(EdgeValue value) {
+        if(value == EdgeValue.BEFORE) {
+            iKey.append(Key.BEFORE);
+        } else if(value == EdgeValue.AFTER) {
+            iKey.append(Key.AFTER);
+        } else {
+            throw new UnsupportedOperationException(value.toString());
+        }
+
+    }
+
+    @Override
+    public void resetForRead(Index index, Key key, Value value) {
+        this.index = index;
+        this.iKey = key;
+        this.iValue = value;
+        this.pKeyTarget = null;
+        this.pKeyFields = index.getAllColumns().size();
+        if(value != null) {
+            value.getByteArray(iValue.getEncodedBytes(), 0, 0, value.getArrayLength());
+            iValue.setEncodedSize(value.getArrayLength());
+        }
+        zPosition = index.isSpatial() ? index.firstSpatialArgument() : -1;
+    }
+
+    @Override
+    public void resetForWrite(Index index, Key key) {
+        this.index = index;
+        this.iKey = key;
+        this.iValue = null;
+        this.pKeyFields = index.getAllColumns().size();
+        if(this.pKeyTarget == null) {
+            this.pKeyTarget = SORT_KEY_ADAPTER.createTarget(index.getIndexName());
+        }
+        this.pKeyTarget.attach(key);
+        zPosition = index.isSpatial() ? index.firstSpatialArgument() : -1;
+    }
+
+    @Override
+    public int compareTo(IndexRow thatKey, int startBoundColumns) {
+        return compareTo(thatKey, startBoundColumns, null);
+    }
+
+    @Override
+    public int compareTo(IndexRow thatKey, int fieldCount, boolean[] ascending) {
+        MemoryIndexRow that = (MemoryIndexRow)thatKey;
+        if(fieldCount <= 0) {
+            return 0;
+        }
+        int c;
+        byte[] thisBytes = this.iKey.getEncodedBytes();
+        byte[] thatBytes = that.iKey.getEncodedBytes();
+        int b = 0; // byte position
+        int f = 0; // field position
+        int thisEnd = this.iKey.getEncodedSize();
+        int thatEnd = that.iKey.getEncodedSize();
+        int end = min(thisEnd, thatEnd);
+        while(b < end && f < pKeyFields) {
+            int thisByte = thisBytes[b] & 0xff;
+            int thatByte = thatBytes[b] & 0xff;
+            c = thisByte - thatByte;
+            if(c != 0) {
+                return isSet(ascending, f, c, -c);
+            } else {
+                b++;
+                if(thisByte == 0) {
+                    if(++f == fieldCount) {
+                        return 0;
+                    }
+                }
+            }
+        }
+        if(thisEnd > thatEnd) {
+            return isSet(ascending, f, 1, -1);
+        }
+        if(thatEnd > thisEnd) {
+            return isSet(ascending, f, -1, 1);
+        }
+        // Compare pValues, if there are any
+        thisBytes = this.iValue == null ? null : this.iValue.getEncodedBytes();
+        thatBytes = that.iValue == null ? null : that.iValue.getEncodedBytes();
+        if(thisBytes == null && thatBytes == null) {
+            return 0;
+        } else if(thisBytes == null) {
+            return isSet(ascending, f, -1, 1);
+        } else if(thatBytes == null) {
+            return isSet(ascending, f, 1, -1);
+        }
+        b = 0;
+        thisEnd = this.iValue.getEncodedSize();
+        thatEnd = that.iValue.getEncodedSize();
+        end = min(thisEnd, thatEnd);
+        while(b < end) {
+            int thisByte = thisBytes[b] & 0xff;
+            int thatByte = thatBytes[b] & 0xff;
+            c = thisByte - thatByte;
+            if(c != 0) {
+                return isSet(ascending, f, c, -c);
+            } else {
+                b++;
+                if(thisByte == 0) {
+                    if(++f == fieldCount) {
+                        return 0;
+                    }
+                }
+            }
+        }
+        if(thisEnd > thatEnd) {
+            return isSet(ascending, f, 1, -1);
+        }
+        if(thatEnd > thisEnd) {
+            return isSet(ascending, f, -1, 1);
+        }
+        return 0;
+    }
+
+    @Override
+    public void reset() {
+        iKey.clear();
+        if(iValue != null) {
+            iValue.clear();
+        }
+    }
+
+    @Override
+    public void copyPersistitKeyTo(Key key) {
+        iKey.copyTo(key);
+    }
+
+    @Override
+    public void appendFieldTo(int position, Key target) {
+        PersistitKey.appendFieldFromKey(target, iKey, position, index.getIndexName());
+    }
+
+    @Override
+    public void copyFrom(Key key, Value value) {
+        key.copyTo(iKey);
+        if(value != null && value.isDefined() && !value.isNull()) {
+            tableBitmap = value.getLong();
+        }
+        leafTableHKey = ancestorHKey(index.leafMostTable());
+    }
+
+    @Override
+    public boolean keyEmpty() {
+        return iKey.getEncodedSize() == 0;
+    }
+
+    @Override
+    public void tableBitmap(long bitmap) {
+        tableBitmap = bitmap;
+    }
+
+    @Override
+    public long tableBitmap() {
+        return tableBitmap;
+    }
+
+    @Override
+    protected int zPosition() {
+        return zPosition;
+    }
+
+    //
+    // Static
+    //
+
+    private static int isSet(boolean[] values, int idx, int tVal, int fVal) {
+        return ((values == null) || values[idx]) ? tVal : fVal;
+    }
+}

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/FDBTableStatusCache.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/FDBTableStatusCache.java
@@ -73,11 +73,6 @@ public class FDBTableStatusCache implements TableStatusCache {
     }
 
     @Override
-    public synchronized TableStatus createTableStatus(int tableID) {
-        return new FDBTableStatus(tableID);
-    }
-
-    @Override
     public synchronized TableStatus getOrCreateVirtualTableStatus(int tableID, VirtualScanFactory factory) {
         VirtualTableStatus status = virtualTableStatusMap.get(tableID);
         if(status == null) {
@@ -129,11 +124,6 @@ public class FDBTableStatusCache implements TableStatusCache {
             this.tableID = table.getTableId();
             byte[] prefixBytes = FDBStoreDataHelper.prefixBytes(table.getPrimaryKeyIncludingInternal().getIndex());
             this.rowCountKey = ByteArrayUtil.join(packedTableStatusPrefix, prefixBytes, ROW_COUNT_PACKED);
-        }
-        
-        public FDBTableStatus(int tableID) {
-            this.tableID = tableID;
-
         }
 
         @Override

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/MemoryTableStatusCache.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/MemoryTableStatusCache.java
@@ -1,0 +1,148 @@
+/**
+ * Copyright (C) 2009-2015 FoundationDB, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.foundationdb.server;
+
+import com.foundationdb.ais.model.PrimaryKey;
+import com.foundationdb.ais.model.Table;
+import com.foundationdb.qp.virtualadapter.VirtualScanFactory;
+import com.foundationdb.server.service.session.Session;
+import com.foundationdb.server.store.MemoryTransaction;
+import com.foundationdb.server.store.MemoryTransactionService;
+import com.foundationdb.server.store.format.MemoryStorageDescription;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.foundationdb.server.store.MemoryStore.join;
+import static com.foundationdb.server.store.MemoryStore.packLong;
+import static com.foundationdb.server.store.MemoryStore.packUUID;
+import static com.foundationdb.server.store.MemoryStore.unpackLong;
+
+public class MemoryTableStatusCache implements TableStatusCache
+{
+    private final Map<Integer,VirtualTableStatus> virtualTableStatusMap = new HashMap<>();
+    private final MemoryTransactionService txnService;
+    private final byte[] statusPrefix;
+
+    public MemoryTableStatusCache(MemoryTransactionService txnService, byte[] statusPrefix) {
+        this.txnService = txnService;
+        this.statusPrefix = statusPrefix;
+    }
+
+    public byte[] getStatusPrefix() {
+        return statusPrefix;
+    }
+
+    //
+    // TableStatusCache
+    //
+
+    @Override
+    public TableStatus createTableStatus(Table table) {
+        return new MemoryTableStatus(table);
+    }
+
+    @Override
+    public synchronized TableStatus getOrCreateVirtualTableStatus(int tableID, VirtualScanFactory factory) {
+        VirtualTableStatus status = virtualTableStatusMap.get(tableID);
+        if(status == null) {
+            status = new VirtualTableStatus(tableID, factory);
+            virtualTableStatusMap.put(tableID, status);
+        }
+        return status;
+    }
+
+    @Override
+    public void detachAIS() {
+        // None
+    }
+
+    @Override
+    public void clearTableStatus(Session session, Table table) {
+        TableStatus status = table.tableStatus();
+        if(status instanceof VirtualTableStatus) {
+            synchronized(virtualTableStatusMap) {
+                virtualTableStatusMap.remove(table.getTableId());
+            }
+        } else {
+            MemoryTableStatus tmStatus = (MemoryTableStatus)status;
+            MemoryTransaction txn = txnService.getTransaction(session);
+            txn.clear(tmStatus.statusKey);
+        }
+    }
+
+
+    //
+    // Internal
+    //
+
+    private class MemoryTableStatus implements TableStatus
+    {
+        private final int tableID;
+        private final byte[] statusKey;
+
+        private MemoryTableStatus(Table table) {
+            this.tableID = table.getTableId();
+            // packLong(tableID) seems like a good option but ALTER keeps same ID => doubles row count
+            PrimaryKey pk = table.getPrimaryKeyIncludingInternal();
+            assert pk != null : table;
+            MemoryStorageDescription sd = (MemoryStorageDescription)pk.getIndex().getStorageDescription();
+            this.statusKey = join(statusPrefix, sd.getUUIDBytes());
+        }
+
+        @Override
+        public void rowDeleted(Session session) {
+            rowsWritten(session, -1);
+        }
+
+        @Override
+        public void rowsWritten(Session session, long count) {
+            setRowCount(session, getRowCount(session) + count);
+        }
+
+        @Override
+        public void truncate(Session session) {
+            setRowCount(session, 0);
+        }
+
+        @Override
+        public long getRowCount(Session session) {
+            MemoryTransaction txn = txnService.getTransaction(session);
+            byte[] value = txn.get(statusKey);
+            return (value == null) ? 0 : unpackLong(value);
+        }
+
+        @Override
+        public long getApproximateRowCount(Session session) {
+            MemoryTransaction txn = txnService.getTransaction(session);
+            byte[] value = txn.getUncommitted(statusKey);
+            return (value == null) ? 0 : unpackLong(value);
+        }
+
+        @Override
+        public int getTableID() {
+            return tableID;
+        }
+
+        @Override
+        public void setRowCount(Session session, long rowCount) {
+            MemoryTransaction txn = txnService.getTransaction(session);
+            txn.set(statusKey, packLong(rowCount));
+        }
+    }
+}

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/PersistitAccumulatorTableStatusCache.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/PersistitAccumulatorTableStatusCache.java
@@ -52,11 +52,6 @@ public class PersistitAccumulatorTableStatusCache implements TableStatusCache {
     }
     
     @Override
-    public synchronized TableStatus createTableStatus(int tableID) {
-        return new AccumulatorStatus(tableID);
-    }
-
-    @Override
     public synchronized TableStatus getOrCreateVirtualTableStatus(int tableID, VirtualScanFactory factory) {
         VirtualTableStatus ts = memoryStatuses.get(tableID);
         if(ts == null) {
@@ -101,10 +96,6 @@ public class PersistitAccumulatorTableStatusCache implements TableStatusCache {
             this.expectedID = table.getTableId();
             Tree tree = getTreeForTable(table);
             rowCount = new AccumulatorAdapter(AccumulatorAdapter.AccumInfo.ROW_COUNT, tree);
-        }
-
-        public AccumulatorStatus(int expectedID) {
-            this.expectedID = expectedID;
         }
 
         @Override

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/TableStatusCache.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/TableStatusCache.java
@@ -23,31 +23,16 @@ import com.foundationdb.server.rowdata.RowDef;
 import com.foundationdb.server.service.session.Session;
 
 public interface TableStatusCache {
-    /**
-     * Create a new TableStatus that will later be attached to the given
-     * tableID. It will not usable until {@link TableStatus#setRowDef(RowDef)}
-     * is called.
-     * @param tableID ID of the table.
-     * @return Associated TableStatus.
-     */
-    TableStatus createTableStatus(int tableID);
+    /** Create a new TableStatus that will later be attached to the given tableID. */
     TableStatus createTableStatus(Table table);
 
     /**
      * Retrieve, or create, a new table status for a virtual table that will be
-     * serviced by the given factory. Unlike statuses returned from the
-     * {@link #createTableStatus(int)} method, these are saved by the TableStatusCache.
-     * @param tableID ID of the table.
-     * @param factory Factory providing rowCount.
-     * @return Associated TableStatus;
+     * serviced by the given factory. These are saved by the TableStatusCache.
      */
     TableStatus getOrCreateVirtualTableStatus(int tableID, VirtualScanFactory factory);
 
-    /**
-     * Clean up any AIS associated state stored by this cache or any of its
-     * TableStatuses. At a minimum, this will set the RowDef of each TableStatus
-     * to <code>null</code>.
-     */
+    /** Clean up any AIS associated state stored by this cache or any of its TableStatuses. */
     void detachAIS();
 
     /** Permanently remove any state associated with the given table. */

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/error/ErrorCode.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/error/ErrorCode.java
@@ -262,6 +262,7 @@ public enum ErrorCode {
     FDB_FUTURE_VERSION      ("40", "005", Importance.ERROR, FDBFutureVersionException.class),
     //40006-9 open
     TABLE_VERSION_CHANGED   ("40", "00A", Importance.ERROR, TableVersionChangedException.class),
+    LOCK_TIMEOUT            ("40", "00B", Importance.DEBUG, LockTimeoutException.class),
 
     // Class 42 - syntax error or access rule violation
     // These exceptions are re-thrown errors from the parser and from the

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/error/LockTimeoutException.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/error/LockTimeoutException.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (C) 2009-2015 FoundationDB, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.foundationdb.server.error;
+
+public class LockTimeoutException extends InvalidOperationException
+{
+    public LockTimeoutException(int elapsedMillis, String lockType, String lockDesc) {
+        super(ErrorCode.LOCK_TIMEOUT, elapsedMillis, lockType, lockDesc);
+    }
+}

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/service/statusmonitor/DummyStatusMonitor.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/service/statusmonitor/DummyStatusMonitor.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (C) 2009-2015 FoundationDB, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.foundationdb.server.service.statusmonitor;
+
+import com.foundationdb.server.service.Service;
+
+public class DummyStatusMonitor implements StatusMonitorService, Service
+{
+    @Override
+    public void start() {
+        // None
+    }
+
+    @Override
+    public void stop() {
+        // None
+    }
+
+    @Override
+    public void crash() {
+        // None
+    }
+}

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/AbstractStore.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/AbstractStore.java
@@ -558,7 +558,9 @@ public abstract class AbstractStore<SType extends AbstractStore,SDType,SSDType e
             deleteSequences(session, Collections.singleton(table.getIdentityColumn().getIdentityGenerator()));
         }
         // And the group tree
-        removeTree(session, table.getGroup());
+        if(table.isRoot()) {
+            removeTree(session, table.getGroup());
+        }
     }
 
     @Override

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/ConstraintHandler.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/ConstraintHandler.java
@@ -598,15 +598,20 @@ public abstract class ConstraintHandler<SType extends AbstractStore,SDType,SSDTy
     
     public static String formatKey(Session session, Index index, Key key,
                                    List<Column> reportColumns, List<Column> indexColumns) {
-        StringBuilder str = new StringBuilder();
         key.reset();
+        Object[] reportColumnValues = new Object[reportColumns.size()];
         for (int i = 0; i < index.getKeyColumns().size(); i++) {
-            if (i > 0) {
+            int idx = indexColumns.indexOf(index.getKeyColumns().get(i).getColumn());
+            reportColumnValues[idx] = key.decode();
+        }
+        StringBuilder str = new StringBuilder();
+        for(int i = 0; i < reportColumns.size(); ++i) {
+            if (str.length() > 0) {
                 str.append(" and ");
             }
-            str.append(reportColumns.get(indexColumns.indexOf(index.getKeyColumns().get(i).getColumn())).getName());
+            str.append(reportColumns.get(i).getName());
             str.append(" = ");
-            str.append(key.decode());
+            str.append(reportColumnValues[i]);
         }
         return str.toString();
     }

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/FDBStore.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/FDBStore.java
@@ -581,7 +581,7 @@ public class FDBStore extends AbstractStore<FDBStore,FDBStoreData,FDBStorageDesc
     }
 
     @Override
-    public Collection<String> getStorageDescriptionNames() {
+    public Collection<String> getStorageDescriptionNames(Session session) {
         final List<List<String>> dataDirs = Arrays.asList(
             Arrays.asList(FDBNameGenerator.DATA_PATH_NAME, FDBNameGenerator.TABLE_PATH_NAME),
             Arrays.asList(FDBNameGenerator.DATA_PATH_NAME, FDBNameGenerator.SEQUENCE_PATH_NAME),

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/FDBStore.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/FDBStore.java
@@ -612,6 +612,11 @@ public class FDBStore extends AbstractStore<FDBStore,FDBStoreData,FDBStorageDesc
         return FDBNotCommittedException.class;
     }
 
+    @Override
+    public boolean isRestartable() {
+        return true;
+    }
+
     //
     // KeyCreator
     //

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/MemoryConstraintHandler.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/MemoryConstraintHandler.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (C) 2009-2015 FoundationDB, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.foundationdb.server.store;
+
+import com.foundationdb.ais.model.ForeignKey;
+import com.foundationdb.ais.model.ForeignKey.Action;
+import com.foundationdb.ais.model.Index;
+import com.foundationdb.qp.row.Row;
+import com.foundationdb.server.service.ServiceManager;
+import com.foundationdb.server.service.config.ConfigurationService;
+import com.foundationdb.server.service.session.Session;
+import com.foundationdb.server.store.format.MemoryStorageDescription;
+import com.foundationdb.server.types.service.TypesRegistryService;
+
+public class MemoryConstraintHandler extends ConstraintHandler<MemoryStore,MemoryStoreData,MemoryStorageDescription>
+{
+    private final MemoryTransactionService txnService;
+
+    protected MemoryConstraintHandler(MemoryStore store,
+                                      MemoryTransactionService txnService,
+                                      ConfigurationService config,
+                                      TypesRegistryService typesRegistryService,
+                                      ServiceManager serviceManager) {
+        super(store, config, typesRegistryService, serviceManager);
+        this.txnService = txnService;
+    }
+
+    @Override
+    protected void checkReferencing(Session session,
+                                    Index index,
+                                    MemoryStoreData storeData,
+                                    Row row,
+                                    ForeignKey foreignKey,
+                                    String operation) {
+        assert index.isUnique() : index;
+        MemoryIndexChecks.CheckPass finalPass =
+            txnService.isDeferred(session, foreignKey) ?
+                MemoryIndexChecks.CheckPass.TRANSACTION :
+                MemoryIndexChecks.CheckPass.ROW;
+        MemoryIndexChecks.IndexCheck check =
+            MemoryIndexChecks.foreignKeyReferencingCheck(storeData, index, foreignKey, finalPass, operation);
+        txnService.addPendingCheck(session, check);
+    }
+
+    @Override
+    protected void checkNotReferenced(Session session,
+                                      Index index,
+                                      MemoryStoreData storeData,
+                                      Row row,
+                                      ForeignKey foreignKey,
+                                      boolean selfReference,
+                                      Action action,
+                                      String operation) {
+        MemoryIndexChecks.CheckPass finalPass;
+        if(action == ForeignKey.Action.RESTRICT) {
+            finalPass = MemoryIndexChecks.CheckPass.ROW;
+        } else if(txnService.isDeferred(session, foreignKey)) {
+            finalPass = MemoryIndexChecks.CheckPass.TRANSACTION;
+        } else {
+            finalPass = MemoryIndexChecks.CheckPass.STATEMENT;
+        }
+        MemoryIndexChecks.IndexCheck check =
+            MemoryIndexChecks.foreignKeyNotReferencedCheck(storeData,
+                                                           index,
+                                                           (row == null),
+                                                           foreignKey,
+                                                           selfReference,
+                                                           finalPass,
+                                                           operation);
+        txnService.addPendingCheck(session, check);
+    }
+}

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/MemoryIndexChecks.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/MemoryIndexChecks.java
@@ -1,0 +1,347 @@
+/**
+ * Copyright (C) 2009-2015 FoundationDB, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.foundationdb.server.store;
+
+import com.foundationdb.ais.model.ForeignKey;
+import com.foundationdb.ais.model.Index;
+import com.foundationdb.server.error.ForeignKeyReferencedViolationException;
+import com.foundationdb.server.error.ForeignKeyReferencingViolationException;
+import com.foundationdb.server.error.InvalidOperationException;
+import com.foundationdb.server.service.session.Session;
+import com.persistit.Key;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map.Entry;
+
+import static com.foundationdb.server.store.MemoryStore.BYTES_00;
+import static com.foundationdb.server.store.MemoryStore.BYTES_FF;
+import static com.foundationdb.server.store.MemoryStore.join;
+import static com.foundationdb.server.store.MemoryStore.packKey;
+import static com.foundationdb.server.store.MemoryStore.unpackKey;
+
+public class MemoryIndexChecks
+{
+    public static enum CheckPass
+    {
+        ROW,
+        STATEMENT,
+        TRANSACTION,
+    }
+
+    public static class PendingChecks
+    {
+        private final List<IndexCheck> pending;
+
+        public PendingChecks() {
+            this.pending = new ArrayList<>();
+        }
+
+        public void add(Session session, MemoryTransaction txn, IndexCheck check) {
+            pending.add(check);
+            performChecks(session, txn, CheckPass.ROW);
+        }
+
+        protected void performChecks(Session session, MemoryTransaction txn, CheckPass pass) {
+            Iterator<IndexCheck> it = pending.iterator();
+            while(it.hasNext()) {
+                IndexCheck check = it.next();
+                if(check.isReady(session, pass)) {
+                    check.query(session, txn);
+                    if(!check.check(session, pass)) {
+                        throw check.createException(session);
+                    }
+                    it.remove();
+                }
+            }
+        }
+
+        public void clear() {
+            pending.clear();
+        }
+    }
+
+    public static IndexCheck foreignKeyReferencingCheck(MemoryStoreData storeData,
+                                                        Index index,
+                                                        ForeignKey foreignKey,
+                                                        CheckPass finalPass,
+                                                        String operation) {
+        byte[][] bounds = makeBounds(storeData, index);
+        return new ForeignKeyReferencingCheck(index, bounds[0], bounds[1], foreignKey, finalPass, operation);
+    }
+
+    public static IndexCheck foreignKeyNotReferencedCheck(MemoryStoreData storeData,
+                                                          Index index,
+                                                          boolean isWholeIndex,
+                                                          ForeignKey foreignKey,
+                                                          boolean isSelfReference,
+                                                          CheckPass finalPass,
+                                                          String operation) {
+        if(isWholeIndex) {
+            byte[] begin = packKey(index);
+            byte[] end = join(begin, BYTES_FF);
+            return new ForeignKeyNotReferencedWholeCheck(index, begin, end, foreignKey, finalPass, operation);
+        }
+        byte[][] bounds = makeBounds(storeData, index);
+        if(isSelfReference) {
+            return new ForeignKeyNotReferencedSkipSelfCheck(index, bounds[0], bounds[1], foreignKey, finalPass, operation);
+        }
+        return new ForeignKeyNotReferencedCheck(index, bounds[0], bounds[1], foreignKey, finalPass, operation);
+    }
+
+    //
+    // Internal
+    //
+
+    private static enum FoundValue
+    {
+        NONE,
+        ONE,
+        MULTIPLE,
+    }
+
+    public static abstract class IndexCheck {
+        protected final Index index;
+        protected final byte[] beginKey;
+        protected final byte[] endKey;
+        protected FoundValue foundValue;
+
+        protected IndexCheck(Index index, byte[] beginKey, byte[] endKey) {
+            this.index = index;
+            this.beginKey = beginKey;
+            this.endKey = endKey;
+        }
+
+        /** Perform the index check. */
+        public void query(Session session, MemoryTransaction txn) {
+            if(endKey == null) {
+                byte[] value = txn.get(beginKey);
+                foundValue = (value == null) ? FoundValue.NONE : FoundValue.ONE;
+            } else {
+                Iterator<Entry<byte[], byte[]>> it = txn.getRange(beginKey, endKey);
+                if(!it.hasNext()) {
+                    foundValue = FoundValue.NONE;
+                } else {
+                    it.next();
+                    foundValue = it.hasNext() ? FoundValue.MULTIPLE : FoundValue.ONE;
+                }
+            }
+
+        }
+
+        public boolean isReady(Session session, CheckPass pass) {
+            return true;
+        }
+
+        /** Return <code>true</code> if the check passes. */
+        public abstract boolean check(Session session, CheckPass pass);
+
+        /** Create appropriate exception for failed check. */
+        public abstract InvalidOperationException createException(Session session);
+    }
+
+    private static abstract class ForeignKeyCheck extends IndexCheck
+    {
+        protected final ForeignKey foreignKey;
+        protected final String operation;
+        protected final CheckPass finalPass;
+
+        protected ForeignKeyCheck(Index index,
+                                  byte[] beginKey,
+                                  byte[] endKey,
+                                  ForeignKey foreignKey,
+                                  CheckPass finalPass,
+                                  String operation) {
+            super(index, beginKey, endKey);
+            this.foreignKey = foreignKey;
+            this.finalPass = finalPass;
+            this.operation = operation;
+        }
+
+        public boolean isReady(Session session, CheckPass pass) {
+            return (finalPass.ordinal() <= pass.ordinal());
+        }
+    }
+
+    private static class ForeignKeyReferencingCheck extends ForeignKeyCheck
+    {
+        public ForeignKeyReferencingCheck(Index index,
+                                          byte[] beginKey,
+                                          byte[] endKey,
+                                          ForeignKey foreignKey,
+                                          CheckPass finalPass,
+                                          String operation) {
+            super(index, beginKey, endKey, foreignKey, finalPass, operation);
+        }
+
+        @Override
+        public boolean check(Session session, CheckPass pass) {
+            assert foundValue != null;
+            return foundValue != FoundValue.NONE;
+        }
+
+        @Override
+        public InvalidOperationException createException(Session session) {
+            Key persistitKey = new Key(null, 2047);
+            unpackKey(index, beginKey, persistitKey);
+            String key = ConstraintHandler.formatKey(session,
+                                                     index,
+                                                     persistitKey,
+                                                     foreignKey.getReferencingColumns(),
+                                                     foreignKey.getReferencedColumns());
+            return new ForeignKeyReferencingViolationException(operation,
+                                                               foreignKey.getReferencingTable().getName(),
+                                                               key,
+                                                               foreignKey.getConstraintName().getTableName(),
+                                                               foreignKey.getReferencedTable().getName());
+        }
+    }
+
+    private static class ForeignKeyNotReferencedCheck extends ForeignKeyCheck
+    {
+        public ForeignKeyNotReferencedCheck(Index index,
+                                            byte[] beginKey,
+                                            byte[] endKey,
+                                            ForeignKey foreignKey,
+                                            CheckPass finalPass,
+                                            String operation) {
+            super(index, beginKey, endKey, foreignKey, finalPass, operation);
+        }
+
+        @Override
+        public boolean check(Session session, CheckPass pass) {
+            assert foundValue != null;
+            switch(foundValue) {
+                case NONE:
+                    return true;
+                case ONE:
+                    return isOneAllowed(pass);
+                case MULTIPLE:
+                    return false;
+                default:
+                    throw new IllegalStateException(foundValue.toString());
+            }
+        }
+
+        protected boolean isOneAllowed(CheckPass pass) {
+            return false;
+        }
+
+        @Override
+        public InvalidOperationException createException(Session session) {
+            Key persistitKey = new Key(null, 2047);
+            unpackKey(index, beginKey, persistitKey);
+            String key = ConstraintHandler.formatKey(session, index, persistitKey,
+                                                     foreignKey.getReferencedColumns(),
+                                                     foreignKey.getReferencingColumns());
+            return new ForeignKeyReferencedViolationException(operation,
+                                                              foreignKey.getReferencedTable().getName(),
+                                                              key,
+                                                              foreignKey.getConstraintName().getTableName(),
+                                                              foreignKey.getReferencingTable().getName());
+        }
+    }
+
+    private static class ForeignKeyNotReferencedSkipSelfCheck extends  ForeignKeyNotReferencedCheck
+    {
+        public ForeignKeyNotReferencedSkipSelfCheck(Index index,
+                                                    byte[] beginKey,
+                                                    byte[] endKey,
+                                                    ForeignKey foreignKey,
+                                                    CheckPass finalPass,
+                                                    String operation) {
+            super(index, beginKey, endKey, foreignKey, finalPass, operation);
+        }
+
+        @Override
+        public boolean isOneAllowed(CheckPass pass) {
+            return (pass == CheckPass.ROW);
+        }
+    }
+
+    static class ForeignKeyNotReferencedWholeCheck extends ForeignKeyCheck
+    {
+        private Key persistitKey;
+        private Iterator<Entry<byte[],byte[]>> iterator;
+
+        public ForeignKeyNotReferencedWholeCheck(Index index,
+                                                 byte[] beginKey,
+                                                 byte[] endKey,
+                                                 ForeignKey foreignKey,
+                                                 CheckPass finalPass,
+                                                 String operation) {
+            super(index, beginKey, endKey, foreignKey, finalPass, operation);
+        }
+
+        private void ensureKey() {
+            if(persistitKey == null) {
+                persistitKey = new Key(null, 2047);
+            }
+        }
+
+        @Override
+        public void query(Session session, MemoryTransaction txn) {
+            iterator = txn.getRange(beginKey, endKey);
+        }
+
+        @Override
+        public boolean check(Session session, CheckPass pass) {
+            while(iterator.hasNext()) {
+                ensureKey();
+                byte[] rawKey = iterator.next().getKey();
+                unpackKey(index, rawKey, persistitKey);
+                if(!ConstraintHandler.keyHasNullSegments(persistitKey, index)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        @Override
+        public InvalidOperationException createException(Session session) {
+            // Should have been filled in failed check()
+            assert persistitKey != null;
+            String key = ConstraintHandler.formatKey(session,
+                                                     index,
+                                                     persistitKey,
+                                                     foreignKey.getReferencedColumns(),
+                                                     foreignKey.getReferencingColumns());
+            return new ForeignKeyReferencedViolationException(operation,
+                                                              foreignKey.getReferencedTable().getName(),
+                                                              key,
+                                                              foreignKey.getConstraintName().getTableName(),
+                                                              foreignKey.getReferencingTable().getName());
+        }
+    }
+
+    private static byte[][] makeBounds(MemoryStoreData storeData, Index index) {
+        packKey(storeData);
+        byte[] begin;
+        byte[] end = null;
+        // Normal case, reference does not contain all columns
+        if(storeData.persistitKey.getDepth() < index.getAllColumns().size()) {
+            begin = join(storeData.rawKey, BYTES_00);
+            end = join(storeData.rawKey, BYTES_FF);
+        } else {
+            // Exactly matches index, including HKey columns
+            begin = join(storeData.rawKey);
+        }
+        return new byte[][]{ begin, end };
+    }
+}

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/MemorySchemaManager.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/MemorySchemaManager.java
@@ -1,0 +1,601 @@
+/**
+ * Copyright (C) 2009-2015 FoundationDB, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.foundationdb.server.store;
+
+import com.foundationdb.ais.model.AbstractVisitor;
+import com.foundationdb.ais.model.AkibanInformationSchema;
+import com.foundationdb.ais.model.DefaultNameGenerator;
+import com.foundationdb.ais.model.Group;
+import com.foundationdb.ais.model.HasStorage;
+import com.foundationdb.ais.model.Index;
+import com.foundationdb.ais.model.NameGenerator;
+import com.foundationdb.ais.model.Sequence;
+import com.foundationdb.ais.model.StorageDescription;
+import com.foundationdb.ais.model.Table;
+import com.foundationdb.ais.model.TableName;
+import com.foundationdb.ais.model.validation.AISValidations;
+import com.foundationdb.ais.protobuf.ProtobufReader;
+import com.foundationdb.ais.protobuf.ProtobufWriter;
+import com.foundationdb.qp.virtualadapter.VirtualAdapter;
+import com.foundationdb.server.TableStatus;
+import com.foundationdb.server.MemoryTableStatusCache;
+import com.foundationdb.server.rowdata.RowDefBuilder;
+import com.foundationdb.server.service.config.ConfigurationService;
+import com.foundationdb.server.service.session.Session;
+import com.foundationdb.server.service.session.SessionService;
+import com.foundationdb.server.service.transaction.TransactionService;
+import com.foundationdb.server.service.transaction.TransactionService.Callback;
+import com.foundationdb.server.store.TableChanges.ChangeSet;
+import com.foundationdb.server.store.format.MemoryStorageDescription;
+import com.foundationdb.server.store.format.MemoryStorageFormatRegistry;
+import com.foundationdb.server.types.service.TypesRegistryService;
+import com.google.inject.Inject;
+import com.persistit.Key;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+
+import static com.foundationdb.server.store.MemoryStore.BYTES_00;
+import static com.foundationdb.server.store.MemoryStore.BYTES_EMPTY;
+import static com.foundationdb.server.store.MemoryStore.BYTES_FF;
+import static com.foundationdb.server.store.MemoryStore.join;
+import static com.foundationdb.server.store.MemoryStore.packLong;
+import static com.foundationdb.server.store.MemoryStore.packUUID;
+import static com.foundationdb.server.store.MemoryStore.unpackLong;
+import static com.foundationdb.server.store.MemoryStore.unpackUUID;
+
+/**
+ * "Subspace" layout:
+ * smBytes/
+ *   "online"/
+ *     online_id/
+ *       "changes"/
+ *         table_id         => [ChangeSet protobuf]
+ *       "error"            => [error message UTF-8]
+ *       "generation"       => [generation long]
+ *       "hkeys"/
+ *         table_id/
+ *           hkey_bytes       => []
+ *       "protobuf"/
+ *         schema_name      => [AIS protobuf]
+ *   "online_session_id"    => [session id long]
+ *   "protobuf
+ * tsBytes/
+ *   pkBytes                => [row count long]
+ */
+public class MemorySchemaManager extends AbstractSchemaManager
+{
+    private static final Session.Key<AkibanInformationSchema> SESSION_AIS_KEY = Session.Key.named("AIS");
+
+    private static final Charset UTF8 = Charset.forName("UTF-8");
+    private static final byte[] CHANGES_STR_BYTES = "changes".getBytes(UTF8);
+    private static final byte[] ERROR_STR_BYTES = "error".getBytes(UTF8);
+    private static final byte[] GENERATION_STR_BYTES = "generation".getBytes(UTF8);
+    private static final byte[] HKEYS_STR_BYTES = "hkeys".getBytes(UTF8);
+    private static final byte[] ONLINE_STR_BYTES = "online".getBytes(UTF8);
+    private static final byte[] ONLINE_SESSION_ID_STR_BYTES = "online_session_id".getBytes(UTF8);
+    private static final byte[] PROTOBUF_STR_BYTES = "protobuf".getBytes(UTF8);
+
+    private final MemoryTransactionService txnService;
+    private final byte[] smBytes = packUUID(UUID.randomUUID());
+    private final byte[] tsBytes = packUUID(UUID.randomUUID());
+
+    private volatile MemoryTableStatusCache tableStatusCache;
+    private volatile AkibanInformationSchema curAIS;
+    private volatile NameGenerator nameGenerator;
+
+    @Inject
+    public MemorySchemaManager(ConfigurationService config,
+                               SessionService sessionService,
+                               TransactionService txnService,
+                               TypesRegistryService typesRegistryService) {
+        super(config, sessionService, txnService, typesRegistryService, new MemoryStorageFormatRegistry(config));
+        this.txnService = (MemoryTransactionService)txnService;
+    }
+
+    //
+    // Service
+    //
+
+    @Override
+    public void start() {
+        super.start();
+        tableStatusCache = new MemoryTableStatusCache(txnService, tsBytes);
+        nameGenerator = new DefaultNameGenerator();
+
+    }
+
+    @Override
+    public void stop() {
+        nameGenerator = null;
+        curAIS = null;
+        tableStatusCache = null;
+        super.stop();
+    }
+
+    @Override
+    public void crash() {
+        stop();
+    }
+
+    //
+    // AbstractSchemaManager
+    //
+
+    @Override
+    protected NameGenerator getNameGenerator(Session session) {
+        return nameGenerator;
+    }
+
+    @Override
+    protected AkibanInformationSchema getSessionAIS(Session session) {
+        MemoryTransaction txn = getTransaction(session);
+        AkibanInformationSchema localAIS = session.get(SESSION_AIS_KEY);
+        if(localAIS != null) {
+            return localAIS;
+        }
+        localAIS = curAIS;
+        if(localAIS == null) {
+            synchronized(this) {
+                if(curAIS == null) {
+                    curAIS = loadFromStorage(txn);
+                    nameGenerator.mergeAIS(curAIS);
+                }
+                localAIS = curAIS;
+            }
+        }
+        long localGen = getCurrentAISGeneration(txn);
+        if(localGen != localAIS.getGeneration()) {
+            localAIS = loadFromStorage(txn);
+            synchronized(this) {
+                if(localAIS.getGeneration() > curAIS.getGeneration()) {
+                    curAIS = localAIS;
+                }
+            }
+        }
+        attachToSession(session, localAIS);
+        return localAIS;
+    }
+
+    @Override
+    protected void storedAISChange(Session session, AkibanInformationSchema newAIS, Collection<String> schemas) {
+        MemoryTransaction txn = getTransaction(session);
+        validateAndFreeze(txn, newAIS, null);
+        attachToSession(session, newAIS);
+        for(String schema : schemas) {
+            storeProtobuf(txn, join(smBytes, PROTOBUF_STR_BYTES), newAIS, schema);
+        }
+        buildRowDefs(newAIS);
+    }
+
+    @Override
+    protected void unStoredAISChange(Session session, AkibanInformationSchema newAIS) {
+        // Treat as normal change as everything goes away on restart anyway.
+        storedAISChange(session,
+                        newAIS,
+                        Arrays.asList(TableName.INFORMATION_SCHEMA,
+                                      TableName.SECURITY_SCHEMA,
+                                      TableName.SQLJ_SCHEMA,
+                                      TableName.SYS_SCHEMA));
+    }
+
+    @Override
+    protected void renamingTable(Session session, TableName oldName, TableName newName) {
+        // None
+    }
+
+    @Override
+    protected void clearTableStatus(Session session, Table table) {
+        tableStatusCache.clearTableStatus(session, table);
+    }
+
+    @Override
+    protected void bumpGeneration(Session session) {
+        MemoryTransaction txn = getTransaction(session);
+        getNextAISGeneration(txn);
+    }
+
+    @Override
+    protected long generateSaveOnlineSessionID(Session session) {
+        MemoryTransaction txn = getTransaction(session);
+        byte[] key = join(smBytes, ONLINE_SESSION_ID_STR_BYTES);
+        byte[] value = txn.get(key);
+        long nextID = 1;
+        if(value != null) {
+            nextID = unpackLong(value) + 1;
+        }
+        txn.set(key, packLong(nextID));
+        return nextID;
+    }
+
+    @Override
+    protected void storedOnlineChange(Session session,
+                                      OnlineSession onlineSession,
+                                      AkibanInformationSchema newAIS,
+                                      Collection<String> schemas) {
+        MemoryTransaction txn = getTransaction(session);
+        // Get a unique generation for this AIS, but will only be visible to owning session
+        validateAndFreeze(txn, newAIS, null);
+        attachToSession(session, newAIS);
+        // Again so no other transactions see the new one from validate
+        bumpGeneration(session);
+        // Save online id
+        byte[] sessionBytes = join(smBytes, ONLINE_STR_BYTES, packLong(onlineSession.id));
+        txn.set(sessionBytes, BYTES_EMPTY);
+        // Save online schemas
+        txn.set(join(sessionBytes, GENERATION_STR_BYTES), packLong(newAIS.getGeneration()));
+        byte[] protobufBytes = join(sessionBytes, PROTOBUF_STR_BYTES);
+        for(String name : schemas) {
+            storeProtobuf(txn, protobufBytes, newAIS, name);
+        }
+    }
+
+    @Override
+    protected void clearOnlineState(Session session, OnlineSession onlineSession) {
+        MemoryTransaction txn = getTransaction(session);
+        byte[] sessionBytes = join(smBytes, ONLINE_STR_BYTES, packLong(onlineSession.id));
+        txn.clearRange(sessionBytes, join(sessionBytes, BYTES_FF));
+    }
+
+    @Override
+    protected OnlineCache buildOnlineCache(Session session) {
+        MemoryTransaction txn = getTransaction(session);
+        OnlineCache onlineCache = new OnlineCache();
+        byte[] onlineSessionsBegin = join(smBytes, ONLINE_STR_BYTES, packLong(0));
+        byte[] onlineSessionEnd = join(smBytes, ONLINE_STR_BYTES, packLong(-1));
+        Iterator<Entry<byte[], byte[]>> sessionIt = txn.getRange(onlineSessionsBegin, onlineSessionEnd);
+        // For each online ID
+        while(sessionIt.hasNext()) {
+            Entry<byte[], byte[]> sessionEntry = sessionIt.next();
+            if(sessionEntry.getKey().length != (smBytes.length + ONLINE_STR_BYTES.length + 8)) {
+                continue;
+            }
+            byte[] sessionBytes = sessionEntry.getKey();
+            long onlineID = unpackLong(sessionBytes, sessionBytes.length - 8);
+            byte[] genBytes = txn.get(join(sessionBytes, GENERATION_STR_BYTES));
+            Long generation = (genBytes == null) ? null : unpackLong(genBytes);
+
+            // Load AISs
+            byte[] protobufBytes = join(sessionBytes, PROTOBUF_STR_BYTES);
+            Iterator<Entry<byte[], byte[]>> protobufIt = txn.getRange(join(protobufBytes, BYTES_00),
+                                                                      join(protobufBytes, BYTES_FF));
+            while(protobufIt.hasNext()) {
+                Entry<byte[], byte[]> protobufEntry = protobufIt.next();
+                byte[] schemaKey = protobufEntry.getKey();
+                String schema = new String(schemaKey, protobufBytes.length, schemaKey.length - protobufBytes.length);
+                Long prev = onlineCache.schemaToOnline.put(schema, onlineID);
+                assert (prev == null) : String.format("%s, %d, %d", schema, prev, onlineID);
+            }
+
+            ProtobufReader reader = newProtobufReader();
+            loadProtobufChildren(txn, reader, protobufBytes, Collections.<String>emptyList());
+            loadProtobufChildren(txn, reader, join(smBytes, PROTOBUF_STR_BYTES), onlineCache.schemaToOnline.keySet());
+            // Reader will have two copies of affected schemas, skip second (i.e. non-online)
+            AkibanInformationSchema newAIS = finishReader(reader);
+            validateAndFreeze(txn, newAIS, generation);
+            buildRowDefs(newAIS);
+            onlineCache.onlineToAIS.put(onlineID, newAIS);
+
+            // Load ChangeSets
+            byte[] changesBytes = join(sessionBytes, CHANGES_STR_BYTES);
+            Iterator<Entry<byte[], byte[]>> changesIt = txn.getRange(join(changesBytes, packLong(0)),
+                                                                     join(changesBytes, packLong(-1)));
+            while(changesIt.hasNext()) {
+                Entry<byte[], byte[]> changeEntry = changesIt.next();
+                ChangeSet cs = ChangeSetHelper.load(changeEntry.getValue());
+                Long prev = onlineCache.tableToOnline.put(cs.getTableId(), onlineID);
+                assert (prev == null) : String.format("%d, %d, %d", cs.getTableId(), prev, onlineID);
+                onlineCache.onlineToChangeSets.put(onlineID, cs);
+            }
+        }
+        return onlineCache;
+    }
+
+    @Override
+    protected void newTableVersions(Session session, Map<Integer, Integer> versions) {
+        // Could track for checking concurrent table conflicts?
+    }
+
+    //
+    // SchemaManager
+    //
+
+    @Override
+    public void addOnlineHandledHKey(Session session, int tableID, Key hKey) {
+        AkibanInformationSchema ais = getAis(session);
+        OnlineCache onlineCache = getOnlineCache(session, ais);
+        Long onlineID = onlineCache.tableToOnline.get(tableID);
+        if(onlineID == null) {
+            throw new IllegalArgumentException("No online change for table: " + tableID);
+        }
+        MemoryTransaction txn = txnService.getTransaction(session);
+        byte[] key = join(smBytes,
+                          ONLINE_STR_BYTES,
+                          packLong(onlineID),
+                          HKEYS_STR_BYTES,
+                          packLong(tableID),
+                          Arrays.copyOf(hKey.getEncodedBytes(), hKey.getEncodedSize()));
+        txn.set(key, BYTES_EMPTY);
+    }
+
+    @Override
+    public Iterator<byte[]> getOnlineHandledHKeyIterator(Session session, int tableID, Key hKey) {
+        OnlineSession onlineSession = getOnlineSession(session, true);
+        MemoryTransaction txn = txnService.getTransaction(session);
+        byte[] hkeyPrefix = join(smBytes,
+                                 ONLINE_STR_BYTES,
+                                 packLong(onlineSession.id),
+                                 HKEYS_STR_BYTES,
+                                 packLong(tableID));
+        byte[] begin;
+        if(hKey != null) {
+            begin = join(hkeyPrefix, Arrays.copyOf(hKey.getEncodedBytes(), hKey.getEncodedSize()));
+        } else {
+            begin = join(hkeyPrefix, BYTES_00);
+        }
+        byte[] end = join(hkeyPrefix, BYTES_FF);
+        final Iterator<Entry<byte[], byte[]>> iterator = txn.getRange(begin, end);
+        final int prefixLength = hkeyPrefix.length;
+        return new Iterator<byte[]>() {
+            @Override
+            public boolean hasNext() {
+                return iterator.hasNext();
+            }
+
+            @Override
+            public byte[] next() {
+                if(!iterator.hasNext()) {
+                    return null;
+                }
+                byte[] keyBytes = iterator.next().getKey();
+                return Arrays.copyOfRange(keyBytes, prefixLength, keyBytes.length);
+            }
+
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+
+    @Override
+    public void setOnlineDMLError(Session session, int tableID, String message) {
+        MemoryTransaction txn = getTransaction(session);
+        AkibanInformationSchema ais = getAis(session);
+        OnlineCache onlineCache = getOnlineCache(session, ais);
+        Long onlineID = onlineCache.tableToOnline.get(tableID);
+        if(onlineID == null) {
+            throw new IllegalArgumentException("No online change for table: " + tableID);
+        }
+        byte[] key = join(smBytes, ONLINE_STR_BYTES, packLong(onlineID), ERROR_STR_BYTES);
+        txn.set(key, message.getBytes(UTF8));
+    }
+
+    @Override
+    public String getOnlineDMLError(Session session) {
+        MemoryTransaction txn = getTransaction(session);
+        OnlineSession onlineSession = getOnlineSession(session, true);
+        byte[] key = join(smBytes, ONLINE_STR_BYTES, packLong(onlineSession.id), ERROR_STR_BYTES);
+        byte[] value = txn.get(key);
+        return (value == null) ? null : new String(value, UTF8);
+    }
+
+    @Override
+    public void addOnlineChangeSet(Session session, ChangeSet changeSet) {
+        MemoryTransaction txn = getTransaction(session);
+        OnlineSession onlineSession = getOnlineSession(session, true);
+        onlineSession.tableIDs.add(changeSet.getTableId());
+
+        byte[] sessionBytes = join(smBytes, ONLINE_STR_BYTES, packLong(onlineSession.id));
+        txn.set(sessionBytes, BYTES_EMPTY);
+        byte[] key = join(sessionBytes, CHANGES_STR_BYTES, packLong(changeSet.getTableId()));
+        byte[] value = ChangeSetHelper.save(changeSet);
+        txn.set(key, value);
+        // TODO: Cleanup into Abstract. For consistency with PSSM.
+        if(getAis(session).getGeneration() == getOnlineAIS(session).getGeneration()) {
+            bumpGeneration(session);
+        }
+    }
+
+    @Override
+    public Set<String> getTreeNames(final Session session) {
+        return txnService.run(session, new Callable<Set<String>>() {
+            @Override
+            public Set<String> call() throws Exception {
+                AkibanInformationSchema ais = getAis(session);
+                StorageNameVisitor visitor = new StorageNameVisitor();
+                ais.visit(visitor);
+                for(Sequence s : ais.getSequences().values()) {
+                    visitor.visit(s);
+                }
+                visitor.names.add(unpackUUID(smBytes).toString());
+                visitor.names.add(unpackUUID(tableStatusCache.getStatusPrefix()).toString());
+                return visitor.names;
+            }
+        });
+    }
+
+    @Override
+    public long getOldestActiveAISGeneration() {
+        return (curAIS != null) ? curAIS.getGeneration() : -1;
+    }
+
+    @Override
+    public Set<Long> getActiveAISGenerations() {
+        return Collections.singleton(getOldestActiveAISGeneration());
+    }
+
+    @Override
+    public boolean hasTableChanged(Session session, int tableID) {
+        // Handled by locking
+        return false;
+    }
+
+    //
+    // Internal
+    //
+
+    private void attachToSession(Session session, AkibanInformationSchema ais) {
+        // attachToSession
+        AkibanInformationSchema prev = session.put(SESSION_AIS_KEY, ais);
+        if(prev == null) {
+            txnService.addCallback(session, TransactionService.CallbackType.END, CLEAR_SESSION_AIS);
+        }
+    }
+
+    private void buildRowDefs(AkibanInformationSchema ais) {
+        tableStatusCache.detachAIS();
+        for(final Table table : ais.getTables().values()) {
+            final TableStatus status;
+            if(table.isVirtual()) {
+                status = tableStatusCache.getOrCreateVirtualTableStatus(table.getTableId(),
+                                                                        VirtualAdapter.getFactory(table));
+            } else {
+                status = tableStatusCache.createTableStatus(table);
+            }
+            table.tableStatus(status);
+        }
+        RowDefBuilder rowDefBuilder = new RowDefBuilder(null/*session*/, ais, tableStatusCache);
+        rowDefBuilder.build();
+    }
+
+    private long getCurrentAISGeneration(MemoryTransaction txn) {
+        byte[] key = join(smBytes, GENERATION_STR_BYTES);
+        byte[] value = txn.get(key);
+        return (value == null) ? 0 : unpackLong(value);
+    }
+
+    private long getNextAISGeneration(MemoryTransaction txn) {
+        byte[] key = join(smBytes, GENERATION_STR_BYTES);
+        byte[] value = txn.get(key);
+        long nextVal = 1;
+        if(value != null) {
+            nextVal += unpackLong(value);
+        }
+        txn.set(key, packLong(nextVal));
+        return nextVal;
+    }
+
+    private MemoryTransaction getTransaction(Session session) {
+        return txnService.getTransaction(session);
+    }
+
+    private AkibanInformationSchema loadFromStorage(MemoryTransaction txn) {
+        ProtobufReader reader = newProtobufReader();
+        loadProtobufChildren(txn, reader, join(smBytes, PROTOBUF_STR_BYTES), Collections.<String>emptyList());
+        finishReader(reader);
+        validateAndFreeze(txn, reader.getAIS(), getCurrentAISGeneration(txn));
+        AkibanInformationSchema ais = reader.getAIS();
+        buildRowDefs(ais);
+        return ais;
+    }
+
+    private void loadProtobufChildren(MemoryTransaction txn,
+                                      ProtobufReader reader,
+                                      byte[] prefix,
+                                      Collection<String> withoutSchemas) {
+        Iterator<Entry<byte[], byte[]>> protobufIt = txn.getRange(join(prefix, BYTES_00), join(prefix, BYTES_FF));
+        while(protobufIt.hasNext()) {
+            Entry<byte[], byte[]> entry = protobufIt.next();
+            String schema = new String(entry.getKey(), prefix.length, entry.getKey().length - prefix.length);
+            if(withoutSchemas.contains(schema)) {
+                continue;
+            }
+            reader.loadBuffer(ByteBuffer.wrap(entry.getValue()));
+        }
+    }
+
+    private ProtobufReader newProtobufReader() {
+        return new ProtobufReader(typesRegistryService.getTypesRegistry(), storageFormatRegistry);
+    }
+
+    private void storeProtobuf(MemoryTransaction txn, byte[] keyPrefix, AkibanInformationSchema ais, String schema) {
+        ProtobufWriter writer = new ProtobufWriter(new ProtobufWriter.SingleSchemaSelector(schema));
+        writer.save(ais);
+        ByteBuffer bb = ByteBuffer.allocate(writer.getBufferSize());
+        writer.serialize(bb);
+        txn.set(join(keyPrefix, schema.getBytes(UTF8)), bb.array());
+    }
+
+    private void validateAndFreeze(MemoryTransaction txn, AkibanInformationSchema ais, Long generation) {
+        ais.validate(AISValidations.ALL_VALIDATIONS).throwIfNecessary();
+        if(generation == null) {
+            generation = getNextAISGeneration(txn);
+        }
+        ais.setGeneration(generation);
+        ais.freeze();
+    }
+
+    //
+    // Static
+    //
+
+    private static final Callback CLEAR_SESSION_AIS = new Callback()
+    {
+        @Override
+        public void run(Session session, long timestamp) {
+            session.remove(SESSION_AIS_KEY);
+        }
+    };
+
+    private static class StorageNameVisitor extends AbstractVisitor
+    {
+        public final Set<String> names = new TreeSet<>();
+
+        public void add(HasStorage hasStorage) {
+            StorageDescription sd = hasStorage.getStorageDescription();
+            if(sd instanceof MemoryStorageDescription) {
+                MemoryStorageDescription tmsd = (MemoryStorageDescription)sd;
+                names.add(tmsd.getNameString());
+            }
+        }
+
+        @Override
+        public void visit(Group group) {
+            add(group);
+        }
+
+        @Override
+        public void visit(Index index) {
+            add(index);
+        }
+
+        public void visit(Sequence sequence) {
+            add(sequence);
+        }
+    }
+
+    private static AkibanInformationSchema finishReader(ProtobufReader reader) {
+        reader.loadAIS();
+        for(Table table : reader.getAIS().getTables().values()) {
+            // nameGenerator is only needed to generate hidden PK, which shouldn't happen here
+            table.endTable(null);
+        }
+        return reader.getAIS();
+    }
+}

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/MemoryStore.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/MemoryStore.java
@@ -1,0 +1,673 @@
+/**
+ * Copyright (C) 2009-2015 FoundationDB, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.foundationdb.server.store;
+
+import com.foundationdb.ais.model.Column;
+import com.foundationdb.ais.model.Group;
+import com.foundationdb.ais.model.HasStorage;
+import com.foundationdb.ais.model.Index;
+import com.foundationdb.ais.model.Sequence;
+import com.foundationdb.ais.model.StorageDescription;
+import com.foundationdb.ais.model.Table;
+import com.foundationdb.ais.model.TableIndex;
+import com.foundationdb.qp.operator.StoreAdapter;
+import com.foundationdb.qp.row.IndexRow;
+import com.foundationdb.qp.row.Row;
+import com.foundationdb.qp.row.WriteIndexRow;
+import com.foundationdb.qp.rowtype.Schema;
+import com.foundationdb.qp.storeadapter.MemoryAdapter;
+import com.foundationdb.qp.storeadapter.indexrow.SpatialColumnHandler;
+import com.foundationdb.qp.storeadapter.indexrow.MemoryIndexRow;
+import com.foundationdb.qp.util.SchemaCache;
+import com.foundationdb.server.error.DuplicateKeyException;
+import com.foundationdb.server.error.LockTimeoutException;
+import com.foundationdb.server.service.Service;
+import com.foundationdb.server.service.ServiceManager;
+import com.foundationdb.server.service.config.ConfigurationService;
+import com.foundationdb.server.service.listener.ListenerService;
+import com.foundationdb.server.service.session.Session;
+import com.foundationdb.server.service.transaction.TransactionService;
+import com.foundationdb.server.store.TableChanges.ChangeSet;
+import com.foundationdb.server.store.format.MemoryStorageDescription;
+import com.foundationdb.server.types.service.TypesRegistryService;
+import com.foundationdb.util.Strings;
+import com.google.inject.Inject;
+import com.persistit.Key;
+import com.persistit.Persistit;
+import com.persistit.Value;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map.Entry;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+
+public class MemoryStore extends AbstractStore<MemoryStore, MemoryStoreData, MemoryStorageDescription> implements Service
+{
+    static final byte[] BYTES_EMPTY = new byte[0];
+    static final byte[] BYTES_00 = { (byte)0x00 };
+    static final byte[] BYTES_FF = { (byte)0xFF };
+
+    private final ConfigurationService configService;
+    private final MemoryTransactionService txnService;
+
+    @Inject
+    public MemoryStore(ConfigurationService configService,
+                       TransactionService txnService,
+                       SchemaManager schemaManager,
+                       ListenerService listenerService,
+                       TypesRegistryService typesRegistryService,
+                       ServiceManager serviceManager) {
+        super(txnService, schemaManager, listenerService, typesRegistryService, serviceManager);
+        this.configService = configService;
+        this.txnService = (MemoryTransactionService)txnService;
+    }
+
+    //
+    // Service
+    //
+
+    @Override
+    public void start() {
+        this.constraintHandler = new MemoryConstraintHandler(this,
+                                                              txnService,
+                                                              configService,
+                                                              typesRegistryService,
+                                                              serviceManager);
+        boolean withConcurrentDML = Boolean.parseBoolean(configService.getProperty(FEATURE_DDL_WITH_DML_PROP));
+        this.onlineHelper = new OnlineHelper(txnService,
+                                             schemaManager,
+                                             this,
+                                             typesRegistryService,
+                                             constraintHandler,
+                                             withConcurrentDML);
+        listenerService.registerRowListener(onlineHelper);
+    }
+
+    @Override
+    public void stop() {
+        // None
+    }
+
+    @Override
+    public void crash() {
+        stop();
+    }
+
+    //
+    // AbstractStore
+    //
+
+    @Override
+    MemoryStoreData createStoreData(Session session, MemoryStorageDescription storageDescription) {
+        return new MemoryStoreData(session, storageDescription, createKey(), createKey());
+    }
+
+    @Override
+    void releaseStoreData(Session session, MemoryStoreData storeData) {
+        // None
+    }
+
+    @Override
+    MemoryStorageDescription getStorageDescription(MemoryStoreData storeData) {
+        return storeData.storageDescription;
+    }
+
+    @Override
+    Key getKey(Session session, MemoryStoreData storeData) {
+        return storeData.persistitKey;
+    }
+
+    @Override
+    void store(Session session, MemoryStoreData storeData) {
+        MemoryTransaction txn = getTransaction(session);
+        packKey(storeData);
+        if(storeData.persistitValue != null) {
+            storeData.rawValue = Arrays.copyOf(storeData.persistitValue.getEncodedBytes(),
+                                               storeData.persistitValue.getEncodedSize());
+        }
+        txn.set(storeData.rawKey, storeData.rawValue);
+    }
+
+    @Override
+    boolean fetch(Session session, MemoryStoreData storeData) {
+        MemoryTransaction txn = getTransaction(session);
+        packKey(storeData);
+        storeData.rawValue = txn.get(storeData.rawKey);
+        return (storeData.rawValue != null);
+    }
+
+    @Override
+    void clear(Session session, MemoryStoreData storeData) {
+        MemoryTransaction txn = getTransaction(session);
+        packKey(storeData);
+        txn.clear(storeData.rawKey);
+    }
+
+    @Override
+    void resetForWrite(MemoryStoreData storeData, Index index, WriteIndexRow indexRowBuffer) {
+        if(storeData.persistitValue == null) {
+            storeData.persistitValue = new Value((Persistit) null);
+        }
+        indexRowBuffer.resetForWrite(index, storeData.persistitKey, storeData.persistitValue);
+    }
+
+    @Override
+    protected Iterator<Void> createDescendantIterator(Session session, final MemoryStoreData storeData) {
+        groupDescendantsIterator(session, storeData);
+        return new Iterator<Void>() {
+            @Override
+            public boolean hasNext() {
+                return storeData.iterator.hasNext();
+            }
+
+            @Override
+            public Void next() {
+                Entry<byte[], byte[]> entry = storeData.iterator.next();
+                storeData.rawKey = entry.getKey();
+                unpackKey(storeData);
+                // Unpacked by caller
+                storeData.rawValue = entry.getValue();
+                return null;
+            }
+
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+
+    @Override
+    protected IndexRow readIndexRow(Session session, Index parentPKIndex, MemoryStoreData storeData, Row childRow) {
+        MemoryTransaction txn = getTransaction(session);
+        Key parentPkKey = storeData.persistitKey;
+        PersistitKeyAppender keyAppender = PersistitKeyAppender.create(parentPkKey, parentPKIndex.getIndexName());
+        for(Column column : childRow.rowType().table().getParentJoin().getChildColumns()) {
+            keyAppender.append(childRow.value(column.getPosition()), column);
+        }
+        // Only called when child row does not contain full HKey.
+        // Key contents are the logical parent of the actual index entry (if it exists).
+        byte[] key = packKey(parentPKIndex, parentPkKey);
+        byte[] begin = join(key, BYTES_00);
+        byte[] end = join(key, BYTES_FF);
+        Iterator<Entry<byte[], byte[]>> it = txn.getRange(begin, end);
+        MemoryIndexRow indexRow = null;
+        if (it.hasNext()) {
+            Entry<byte[], byte[]> entry = it.next();
+            assert !it.hasNext() : parentPKIndex;
+            assert entry.getValue().length == 0 : parentPKIndex + ", " + Strings.hex(entry.getValue());
+            indexRow = new MemoryIndexRow(this);
+            unpackKey(parentPKIndex, entry.getKey(), parentPkKey);
+            indexRow.resetForRead(parentPKIndex, parentPkKey, null);
+        }
+        return indexRow;
+    }
+
+    @Override
+    protected void lock(Session session, MemoryStoreData storeData, Row row) {
+        MemoryTransaction txn = getTransaction(session);
+        packKey(storeData);
+        txn.get(storeData.rawKey);
+    }
+
+    @Override
+    protected void trackTableWrite(Session session, Table table) {
+        // Needed?
+    }
+
+    //
+    // Store
+    //
+
+    @Override
+    public void writeIndexRow(Session session,
+                              TableIndex index,
+                              Row row,
+                              Key hKey,
+                              WriteIndexRow indexRow,
+                              SpatialColumnHandler spatialColumnHandler,
+                              long zValue,
+                              boolean doLock) {
+        MemoryTransaction txn = getTransaction(session);
+        Key indexKey = createKey();
+        constructIndexRow(session, indexKey, row, index, hKey, indexRow, spatialColumnHandler, zValue, true);
+        checkUniqueness(session, txn, index, row, indexKey);
+        byte[] rawKey = packKey(index, indexKey);
+        txn.set(rawKey, BYTES_EMPTY);
+    }
+
+    @Override
+    public void deleteIndexRow(Session session,
+                               TableIndex index,
+                               Row row,
+                               Key hKey,
+                               WriteIndexRow indexRow,
+                               SpatialColumnHandler spatialColumnHandler,
+                               long zValue,
+                               boolean doLock) {
+        MemoryTransaction txn = getTransaction(session);
+        Key indexKey = createKey();
+        constructIndexRow(session, indexKey, row, index, hKey, indexRow, spatialColumnHandler, zValue, false);
+        byte[] packed = packKey(index, indexKey);
+        txn.clear(packed);
+    }
+
+    @Override
+    public long nextSequenceValue(Session session, Sequence sequence) {
+        MemoryTransaction txn = getTransaction(session);
+        byte[] key = packKey(sequence);
+        byte[] value = txn.get(key);
+        long nextVal = 1;
+        if(value != null) {
+            nextVal += unpackLong(value);
+        }
+        txn.set(key, packLong(nextVal));
+        return sequence.realValueForRawNumber(nextVal);
+    }
+
+    @Override
+    public long curSequenceValue(Session session, Sequence sequence) {
+        MemoryTransaction txn = getTransaction(session);
+        byte[] value = txn.get(packKey(sequence));
+        long seqValue = (value != null) ? unpackLong(value) : 0;
+        return sequence.realValueForRawNumber(seqValue);
+    }
+
+    @Override
+    public void deleteSequences(Session session, Collection<? extends Sequence> sequences) {
+        MemoryTransaction txn = getTransaction(session);
+        for(Sequence s : sequences) {
+            txn.clear(packKey(s));
+        }
+    }
+
+    @Override
+    public void removeTree(Session session, HasStorage object) {
+        MemoryTransaction txn = getTransaction(session);
+        byte[] key = packKey(object);
+        txn.clearRange(key, join(key, BYTES_FF));
+    }
+
+    @Override
+    public void truncateTree(Session session, HasStorage object) {
+        removeTree(session, object);
+    }
+
+    @Override
+    public void truncateIndexes(Session session, Collection<? extends Index> indexes) {
+        for(Index i : indexes) {
+            truncateTree(session, i);
+        }
+    }
+
+    @Override
+    public StoreAdapter createAdapter(Session session) {
+        return new MemoryAdapter(session, configService, this);
+    }
+
+    @Override
+    public boolean treeExists(Session session, StorageDescription storageDescription) {
+        MemoryTransaction txn = getTransaction(session);
+        byte[] key = packKey(storageDescription);
+        byte[] begin = join(key, BYTES_00);
+        byte[] end = join(key, BYTES_FF);
+        return txn.getRange(begin, end).hasNext();
+    }
+
+    @Override
+    public void traverse(Session session, Group group, TreeRecordVisitor visitor) {
+        visitor.initialize(session, this);
+        MemoryStoreData storeData = createStoreData(session, group);
+        groupIterator(session, storeData);
+        while(storeData.next()) {
+            Row row = expandGroupData(session, storeData, SchemaCache.globalSchema(group.getAIS()));
+            visitor.visit(storeData.persistitKey, row);
+        }
+        releaseStoreData(session, storeData);
+    }
+
+    @Override
+    public <V extends IndexVisitor<Key, Value>> V traverse(Session session,
+                                                           Index index,
+                                                           V visitor,
+                                                           long scanTimeLimit,
+                                                           long sleepTime) {
+        MemoryStoreData storeData = createStoreData(session, index);
+        storeData.persistitValue = new Value((Persistit)null);
+        indexIterator(session, storeData, false);
+        while(storeData.next()) {
+            // Key
+            unpackKey(storeData);
+            // Value
+            unpackValue(storeData);
+            // Visit
+            visitor.visit(storeData.persistitKey, storeData.persistitValue);
+        }
+        return visitor;
+    }
+
+    @Override
+    public void discardOnlineChange(Session session, Collection<ChangeSet> changeSets) {
+        // TODO: Find all table and sequences being modified, clear their prefix
+    }
+
+    @Override
+    public void finishOnlineChange(Session session, Collection<ChangeSet> changeSets) {
+        // None
+    }
+
+    @Override
+    public String getName() {
+        return getClass().getSimpleName();
+    }
+
+    @Override
+    public Collection<String> getStorageDescriptionNames(final Session session) {
+        return txnService.run(session, new Callable<Collection<String>>() {
+            @Override
+            public Collection<String> call() throws Exception {
+                MemoryTransaction txn = txnService.getTransaction(session);
+                Set<String> names = new TreeSet<>();
+                /* TODO: This found a bug in ALTER processing (that isn't symptomatic with FDBStore).
+                 Pretend there are no storage names to ignore for now.
+                Iterator<Entry<byte[], byte[]>> it = txn.getRange(BYTES_00, BYTES_FF);
+                while(it.hasNext()) {
+                    Entry<byte[], byte[]> entry = it.next();
+                    UUID uuid = unpackUUID(entry.getKey());
+                    names.add(uuid.toString());
+                }*/
+                return names;
+            }
+        });
+    }
+
+    @Override
+    public Class<? extends Exception> getOnlineDMLFailureException() {
+        return LockTimeoutException.class;
+    }
+
+    @Override
+    public boolean isRestartable() {
+        return false;
+    }
+
+    //
+    // KeyCreator
+    //
+
+    @Override
+    public Key createKey() {
+        return new Key(null, 2047);
+    }
+
+    //
+    // TreeMapStore
+    //
+
+    public Row expandGroupData(Session session, MemoryStoreData storeData, Schema schema) {
+        unpackKey(storeData);
+        return expandRow(session, storeData, schema);
+    }
+
+    /** Iterate over the whole group. */
+    public void groupIterator(Session session, MemoryStoreData storeData) {
+        assert storeData.storageDescription.getObject() instanceof Group : storeData.storageDescription;
+        MemoryTransaction txn = getTransaction(session);
+        byte[] uuidBytes = storeData.storageDescription.getUUIDBytes();
+        storeData.iterator = txn.getRange(uuidBytes, join(uuidBytes, BYTES_FF));
+    }
+
+    /** Iterator over *just* storeData.persistitKey */
+    public void groupKeyIterator(Session session, MemoryStoreData storeData) {
+        assert storeData.storageDescription.getObject() instanceof Group : storeData.storageDescription;
+        MemoryTransaction txn = getTransaction(session);
+        final byte[] key = packKey(storeData.storageDescription, storeData.persistitKey);
+        final byte[] value = txn.get(key);
+        storeData.iterator = new Iterator<Entry<byte[], byte[]>>() {
+            boolean hasReturned = false;
+
+            @Override
+            public boolean hasNext() {
+                return !hasReturned && (value != null);
+            }
+
+            @Override
+            public Entry<byte[], byte[]> next() {
+                if(!hasNext()) {
+                    throw new NoSuchElementException();
+                }
+                hasReturned = true;
+                return new Entry<byte[], byte[]>()  {
+                    @Override
+                    public byte[] getKey() {
+                        return key;
+                    }
+
+                    @Override
+                    public byte[] getValue() {
+                        return value;
+                    }
+
+                    @Override
+                    public byte[] setValue(byte[] value) {
+                        throw new UnsupportedOperationException();
+                    }
+                };
+            }
+
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+
+    /** Iterate over key *and* all descendants. */
+    public void groupKeyAndDescendantsIterator(Session session, MemoryStoreData storeData) {
+        assert storeData.storageDescription.getObject() instanceof Group : storeData.storageDescription;
+        MemoryTransaction txn = getTransaction(session);
+        packKey(storeData);
+        byte[] begin = storeData.rawKey;
+        byte[] end = join(storeData.rawKey, BYTES_FF);
+        storeData.iterator = txn.getRange(begin, end);
+    }
+
+    /** Iterate over *just* the descendants of storeDate.persistitKey */
+    public void groupDescendantsIterator(Session session, MemoryStoreData storeData) {
+        assert storeData.storageDescription.getObject() instanceof Group : storeData.storageDescription;
+        MemoryTransaction txn = getTransaction(session);
+        packKey(storeData);
+        byte[] begin = join(storeData.rawKey, BYTES_00);
+        byte[] end = join(storeData.rawKey, BYTES_FF);
+        storeData.iterator = txn.getRange(begin, end);
+    }
+
+    public void indexIterator(Session session, MemoryStoreData storeData, boolean reverse) {
+        assert storeData.storageDescription.getObject() instanceof Index : storeData.storageDescription;
+        MemoryTransaction txn = getTransaction(session);
+        if(reverse) {
+            byte[] begin = packKey(storeData.storageDescription);
+            byte[] end = packKey(storeData.storageDescription, storeData.persistitKey);
+            storeData.iterator = txn.getRange(begin, end, true);
+        } else {
+            byte[] begin = packKey(storeData.storageDescription, storeData.persistitKey);
+            byte[] end = join(packKey(storeData.storageDescription), BYTES_FF);
+            storeData.iterator = txn.getRange(begin, end, false);
+        }
+    }
+
+    public void setRollbackPending(Session session) {
+        txnService.setRollbackPending(session);
+    }
+
+    //
+    // Internal
+    //
+
+    private void checkUniqueness(Session session, MemoryTransaction txn, Index index, Row row, Key key) {
+        if(index.isUnique() && !hasNullIndexSegments(row, index)) {
+            int realSize = key.getEncodedSize();
+            key.setDepth(index.getKeyColumns().size());
+            try {
+                checkKeyDoesNotExistInIndex(session, txn, row, index, key);
+            } finally {
+                key.setEncodedSize(realSize);
+            }
+        }
+
+    }
+
+    private void checkKeyDoesNotExistInIndex(Session session, MemoryTransaction txn, Row row, Index index, Key key) {
+        assert index.isUnique() : index;
+        byte[] begin = packKey(index, key);
+        byte[] end = join(begin, BYTES_FF);
+        Iterator<Entry<byte[], byte[]>> it = txn.getRange(begin, end);
+        if(it.hasNext()) {
+            // Using RowData, can give better error than check.throwException().
+            String msg = formatIndexRowString(session, row, index);
+            throw new DuplicateKeyException(index.getIndexName(), msg);
+        }
+    }
+
+    private void constructIndexRow(Session session,
+                                   Key indexKey,
+                                   Row row,
+                                   Index index,
+                                   Key hKey,
+                                   WriteIndexRow indexRow,
+                                   SpatialColumnHandler spatialColumnHandler,
+                                   long zValue,
+                                   boolean forInsert) {
+        indexKey.clear();
+        indexRow.resetForWrite(index, indexKey);
+        indexRow.initialize(row, hKey, spatialColumnHandler, zValue);
+        indexRow.close(session, forInsert);
+    }
+
+    private MemoryTransaction getTransaction(Session session) {
+        return txnService.getTransaction(session);
+    }
+
+    //
+    // Static
+    //
+
+    public static byte[] join(byte[]... arrays) {
+        int totalLen = 0;
+        for(byte[] a : arrays) {
+            totalLen += a.length;
+        }
+        byte[] joined = new byte[totalLen];
+        int curOffset = 0;
+        for(byte[] a : arrays) {
+            System.arraycopy(a, 0, joined, curOffset, a.length);
+            curOffset += a.length;
+        }
+        return joined;
+    }
+
+    public static byte[] packLong(long l) {
+        ByteBuffer bb = ByteBuffer.allocate(8);
+        bb.putLong(l);
+        return bb.array();
+    }
+
+    public static byte[] packUUID(UUID uuid) {
+        return join(packLong(uuid.getMostSignificantBits()), packLong(uuid.getLeastSignificantBits()));
+    }
+
+    /** rawKey = join(uuidBytes, persistitKey.getEncodedBytes()) */
+    public static void packKey(MemoryStoreData storeData) {
+        storeData.rawKey = packKey(storeData.storageDescription, storeData.persistitKey);
+    }
+
+    public static byte[] packKey(HasStorage hasStorage) {
+        return packKey(hasStorage.getStorageDescription());
+    }
+
+    public static byte[] packKey(StorageDescription storageDescription) {
+        return ((MemoryStorageDescription)storageDescription).getUUIDBytes();
+    }
+
+    public static byte[] packKey(HasStorage hasStorage, Key key) {
+        return packKey(hasStorage.getStorageDescription(), key);
+    }
+
+    public static byte[] packKey(StorageDescription storageDescription, Key key) {
+        byte[] uuidBytes = packKey(storageDescription);
+        byte[] keyBytes = Arrays.copyOfRange(key.getEncodedBytes(),
+                                             0,
+                                             key.getEncodedSize());
+        return join(uuidBytes, keyBytes);
+    }
+
+    public static UUID unpackUUID(byte[] key) {
+        assert key.length >= 16;
+        long most = unpackLong(key, 0);
+        long least = unpackLong(key, 8);
+        return new UUID(most, least);
+    }
+
+    /** persistitKey from rawKey */
+    public static void unpackKey(MemoryStoreData storeData) {
+        unpackKey(storeData.storageDescription, storeData.rawKey, storeData.persistitKey);
+    }
+
+    /** key from rawKey */
+    public static void unpackKey(HasStorage hasStorage, byte[] rawKey, Key key) {
+        unpackKey(hasStorage.getStorageDescription(), rawKey, key);
+    }
+
+    /** key from rawKey */
+    public static void unpackKey(StorageDescription storageDescription, byte[] rawKey, Key key) {
+        assert storageDescription instanceof MemoryStorageDescription : storageDescription;
+        // At least as long as UUID bytes
+        assert rawKey != null;
+        assert rawKey.length > 16 : rawKey.length;
+
+        key.clear();
+        System.arraycopy(rawKey,
+                         16,
+                         key.getEncodedBytes(),
+                         0,
+                         rawKey.length - 16);
+        key.setEncodedSize(rawKey.length - 16);
+    }
+
+    public static long unpackLong(byte[] bytes) {
+        return unpackLong(bytes, 0);
+    }
+
+    public static long unpackLong(byte[] bytes, int offset) {
+        assert bytes.length - offset >= 8;
+        ByteBuffer bb = ByteBuffer.wrap(bytes, offset, bytes.length - offset);
+        return bb.getLong();
+    }
+
+    public static void unpackValue(MemoryStoreData storeData) {
+        assert storeData.persistitValue != null;
+        storeData.persistitValue.clear();
+        storeData.persistitValue.putEncodedBytes(storeData.rawValue, 0, storeData.rawValue.length);
+    }
+}

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/MemoryStoreData.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/MemoryStoreData.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (C) 2009-2015 FoundationDB, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.foundationdb.server.store;
+
+import com.foundationdb.qp.row.Row;
+import com.foundationdb.server.service.session.Session;
+import com.foundationdb.server.store.format.MemoryStorageDescription;
+import com.persistit.Key;
+import com.persistit.Value;
+
+import java.util.Iterator;
+import java.util.Map.Entry;
+
+public class MemoryStoreData
+{
+    public final Session session;
+    public final MemoryStorageDescription storageDescription;
+    public final Key persistitKey;
+    public final Key endKey;
+    public Value persistitValue;
+    public byte[] rawKey;
+    public byte[] rawValue;
+    public Row row;
+    public Iterator<Entry<byte[],byte[]>> iterator;
+
+    public MemoryStoreData(Session session, MemoryStorageDescription storageDescription, Key persistitKey, Key endKey) {
+        this.session = session;
+        this.storageDescription = storageDescription;
+        this.persistitKey = persistitKey;
+        this.endKey = endKey;
+    }
+
+    public boolean next() {
+        if(iterator.hasNext()) {
+            Entry<byte[], byte[]> entry = iterator.next();
+            rawKey = entry.getKey();
+            rawValue = entry.getValue();
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    public void closeIterator() {
+        if(iterator != null) {
+            iterator = null;
+        }
+    }
+}

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/MemoryTransaction.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/MemoryTransaction.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) 2009-2015 FoundationDB, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.foundationdb.server.store;
+
+import java.util.Iterator;
+import java.util.Map.Entry;
+
+public interface MemoryTransaction
+{
+    byte[] get(byte[] key);
+    byte[] getUncommitted(byte[] key);
+
+    Iterator<Entry<byte[], byte[]>> getRange(byte[] beginKey, byte[] endKey);
+    Iterator<Entry<byte[], byte[]>> getRange(byte[] beginKey, byte[] endKey, boolean reverse);
+
+    void set(byte[] key, byte[] value);
+
+    void clear(byte[] key);
+    void clearRange(byte[] beginKey, byte[] endKey);
+}

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/MemoryTransactionService.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/MemoryTransactionService.java
@@ -1,0 +1,847 @@
+/**
+ * Copyright (C) 2009-2015 FoundationDB, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.foundationdb.server.store;
+
+import com.foundationdb.ais.model.ForeignKey;
+import com.foundationdb.server.error.AkibanInternalException;
+import com.foundationdb.server.error.InvalidOperationException;
+import com.foundationdb.server.error.LockTimeoutException;
+import com.foundationdb.server.error.NoTransactionInProgressException;
+import com.foundationdb.server.error.QueryCanceledException;
+import com.foundationdb.server.error.TransactionAbortedException;
+import com.foundationdb.server.error.TransactionInProgressException;
+import com.foundationdb.server.service.session.Session;
+import com.foundationdb.server.service.session.Session.Key;
+import com.foundationdb.server.service.session.Session.StackKey;
+import com.foundationdb.server.service.transaction.TransactionService;
+import com.foundationdb.sql.parser.IsolationLevel;
+import com.foundationdb.util.MultipleCauseException;
+import com.foundationdb.util.Strings;
+import com.google.common.primitives.UnsignedBytes;
+import com.google.inject.Inject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ * KV storage (via TreeMap<byte[],byte[]) and transaction provider.
+ *
+ * Per-key locking providing repeatable read semantics. No gap locking.
+ *
+ * gets() take read (shared) locks, sets() and clears() take write (exclusive) locks
+ * and shared can be upgraded to exclusive 'optimistically' via tag (StampedLock-ish).
+ *
+ * Uncommitted writes go directly into master KV after (exclusive) lock is acquired and an
+ * undo log is maintained to restore proper state on rollback.
+ *
+ * Lock acquisition has an aggressive (1s) timeout after which a retryable error is thrown.
+ */
+public class MemoryTransactionService implements TransactionService
+{
+    private static final Logger LOG = LoggerFactory.getLogger(MemoryTransactionService.class);
+
+    private static final int PERIODIC_COMMIT_MILLS = 500;
+    private static final int PERIODIC_COMMIT_BYTES = 100000;
+    private static final int LOCK_TIMEOUT_MILLIS = 1 * 1000;
+    private static final Key<MemoryTransactionImpl> TXN_KEY = Key.named("TXN");
+    private static final StackKey<Callback> PRE_COMMIT_KEY = StackKey.stackNamed("TXN_PRE_COMMIT");
+    private static final StackKey<Callback> AFTER_END_KEY = StackKey.stackNamed("TXN_AFTER_END");
+    private static final StackKey<Callback> AFTER_COMMIT_KEY = StackKey.stackNamed("TXN_AFTER_COMMIT");
+    private static final StackKey<Callback> AFTER_ROLLBACK_KEY = StackKey .stackNamed("TXN_AFTER_ROLLBACK");
+
+    private final ConcurrentMap<BytesHolder,TaggedLock> locks;
+    private final KVMap db;
+
+    @Inject
+    public MemoryTransactionService() {
+        this.locks = new ConcurrentHashMap<>();
+        this.db = new KVMap();
+    }
+
+    //
+    // Service
+    //
+
+    @Override
+    public void start() {
+        // None
+    }
+
+    @Override
+    public void stop() {
+        locks.clear();
+        synchronized(db) {
+            db.clear();
+        }
+    }
+
+    @Override
+    public void crash() {
+        stop();
+    }
+
+    //
+    // TransactionService
+    //
+
+    @Override
+    public boolean isTransactionActive(Session session) {
+        return (session.get(TXN_KEY) != null);
+    }
+
+    @Override
+    public boolean isRollbackPending(Session session) {
+        return getTransactionInternal(session).isRollbackPending;
+    }
+
+    @Override
+    public long getTransactionStartTimestamp(Session session) {
+        return getTransactionInternal(session).startMillis;
+    }
+
+    @Override
+    public void beginTransaction(Session session) {
+        if(isTransactionActive(session)) {
+            throw new TransactionInProgressException();
+        }
+        MemoryTransactionImpl txn = new MemoryTransactionImpl(session);
+        session.put(TXN_KEY, txn);
+    }
+
+    @Override
+    public CloseableTransaction beginCloseableTransaction(final Session session) {
+        beginTransaction(session);
+        return new CloseableTransaction()
+        {
+            @Override
+            public void commit() {
+                commitTransaction(session);
+            }
+
+            @Override
+            public void rollback() {
+                rollbackTransaction(session);
+            }
+
+            @Override
+            public void close() {
+                rollbackTransactionIfOpen(session);
+            }
+        };
+    }
+
+    @Override
+    public void commitTransaction(Session session) {
+        if(isRollbackPending(session)) {
+            throw new TransactionAbortedException();
+        }
+        commitInternal(session, false, true);
+    }
+
+    @Override
+    public boolean commitOrRetryTransaction(Session session) {
+        if(isRollbackPending(session)) {
+            throw new TransactionAbortedException();
+        }
+        return commitInternal(session, true, true);
+    }
+
+    @Override
+    public void rollbackTransaction(Session session) {
+        MemoryTransactionImpl txn = getTransactionInternal(session);
+        RuntimeException re = null;
+        try {
+            rollbackInternal(session, txn);
+        } catch(RuntimeException e) {
+            re = e;
+        } finally {
+            end(session, txn, true, re);
+        }
+    }
+
+    @Override
+    public void rollbackTransactionIfOpen(Session session) {
+        if(isTransactionActive(session)) {
+            rollbackTransaction(session);
+        }
+    }
+
+    @Override
+    public boolean periodicallyCommit(Session session) {
+        MemoryTransactionImpl txn = getTransactionInternal(session);
+        if(txn.isTimeToCommit()) {
+            commitInternal(session, false, false);
+            txn.reset();
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public boolean shouldPeriodicallyCommit(Session session) {
+        return getTransactionInternal(session).isTimeToCommit();
+    }
+
+    @Override
+    public void addCallback(Session session, CallbackType type, Callback callback) {
+        session.push(getCallbackKey(type), callback);
+    }
+
+    @Override
+    public void addCallbackOnActive(Session session, CallbackType type, Callback callback) {
+        if(!isTransactionActive(session)) {
+            throw new IllegalStateException("Expected active");
+        }
+        addCallback(session, type, callback);
+    }
+
+    @Override
+    public void addCallbackOnInactive(Session session, CallbackType type, Callback callback) {
+        if(isTransactionActive(session)) {
+            throw new IllegalStateException("Expected inactive");
+        }
+        addCallback(session, type, callback);
+    }
+
+    @Override
+    public void run(Session session, final Runnable runnable) {
+        run(session, new Callable<Void>() {
+            @Override
+            public Void call() throws Exception {
+                runnable.run();
+                return null;
+            }
+        });
+    }
+
+    @Override
+    public <T> T run(Session session, Callable<T> callable) {
+        for(int tries = 1; ; ++tries) {
+            try {
+                beginTransaction(session);
+                T value = callable.call();
+                commitTransaction(session);
+                return value;
+            } catch(InvalidOperationException e) {
+                if(!e.getCode().isRollbackClass()) {
+                    throw e;
+                }
+                // Back-off?
+                LOG.debug("Retrying callable, attempt {}", tries);
+            } catch(RuntimeException e) {
+                throw e;
+            } catch(Exception e) {
+                throw new AkibanInternalException("Unexpected Exception", e);
+            } finally {
+                rollbackTransactionIfOpen(session);
+            }
+        }
+    }
+
+    @Override
+    public void setSessionOption(Session session, SessionOption option, String value) {
+        // None
+    }
+
+    @Override
+    public int markForCheck(Session session) {
+        return -1;
+    }
+
+    @Override
+    public boolean checkSucceeded(Session session, Exception retryException, int sessionCounter) {
+        return false;
+    }
+
+    @Override
+    public void setDeferredForeignKey(Session session, ForeignKey foreignKey, boolean deferred) {
+        MemoryTransactionImpl txn = getTransactionInternal(session);
+        txn.deferredForeignKeys = ForeignKey.setDeferred(txn.deferredForeignKeys, foreignKey, deferred);
+    }
+
+    @Override
+    public void checkStatementConstraints(Session session) {
+        MemoryTransactionImpl txn = getTransactionInternal(session);
+        if(txn.pendingChecks != null) {
+            txn.pendingChecks.performChecks(session, txn, MemoryIndexChecks.CheckPass.STATEMENT);
+        }
+    }
+
+    @Override
+    public boolean getForceImmediateForeignKeyCheck(Session session) {
+        // Only called via Online DDL
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean setForceImmediateForeignKeyCheck(Session session, boolean force) {
+        // Only called via Online DDL
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public IsolationLevel actualIsolationLevel(IsolationLevel level) {
+        return IsolationLevel.REPEATABLE_READ_ISOLATION_LEVEL;
+    }
+
+    @Override
+    public IsolationLevel setIsolationLevel(Session session, IsolationLevel level) {
+        // Ignored.
+        return IsolationLevel.REPEATABLE_READ_ISOLATION_LEVEL;
+    }
+
+    @Override
+    public boolean isolationLevelRequiresReadOnly(Session session, boolean commitNow) {
+        return false;
+    }
+
+    //
+    // TreeMapTransactionImplService
+    //
+
+    public void addPendingCheck(Session session, MemoryIndexChecks.IndexCheck check) {
+        MemoryTransactionImpl txn = getTransactionInternal(session);
+        if(txn.pendingChecks == null) {
+            txn.pendingChecks = new MemoryIndexChecks.PendingChecks();
+        }
+        txn.pendingChecks.add(session, txn, check);
+    }
+
+    public MemoryTransaction getTransaction(Session session) {
+        return getTransactionInternal(session);
+    }
+
+    public boolean isDeferred(Session session, ForeignKey foreignKey) {
+        MemoryTransactionImpl txn = getTransactionInternal(session);
+        return foreignKey.isDeferred(txn.deferredForeignKeys);
+    }
+
+    public void setRollbackPending(Session session) {
+        MemoryTransactionImpl txn = getTransactionInternal(session);
+        txn.isRollbackPending = true;
+    }
+
+    //
+    // Static
+    //
+
+    /** Wrapper class providing equals() and hashCode() for byte[] */
+    private static class BytesHolder
+    {
+        public final byte[] bytes;
+
+        private BytesHolder(byte[] bytes) {
+            assert bytes != null;
+            this.bytes = bytes;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if(this == o) {
+                return true;
+            }
+            if((o == null) || (getClass() != o.getClass())) {
+                return false;
+            }
+            BytesHolder that = (BytesHolder)o;
+            return Arrays.equals(bytes, that.bytes);
+        }
+
+        @Override
+        public int hashCode() {
+            return Arrays.hashCode(bytes);
+        }
+    }
+
+    private static class CopiedEntry implements Entry<byte[], byte[]>
+    {
+        private final byte[] key;
+        private final byte[] value;
+
+        public CopiedEntry(Entry<byte[], byte[]> entry) {
+            this.key = copy(entry.getKey());
+            this.value = copy(entry.getValue());
+        }
+
+        @Override
+        public byte[] getKey() {
+            return key;
+        }
+
+        @Override
+        public byte[] getValue() {
+            return value;
+        }
+
+        @Override
+        public byte[] setValue(byte[] value) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String toString() {
+            return Strings.hex(key) + "=" + Strings.hex(value);
+        }
+    }
+
+    private static class KVMap extends TreeMap<byte[], byte[]>
+    {
+        private static final Comparator<byte[]> COMPARATOR = UnsignedBytes.lexicographicalComparator();
+
+        private static final Comparator<byte[]> REVERSE_COMPARATOR = new Comparator<byte[]>() {
+            @Override
+            public int compare(byte[] o1, byte[] o2) {
+                return COMPARATOR.compare(o2, o1);
+            }
+        };
+
+        public KVMap() {
+            this(Collections.<byte[],byte[]>emptyMap(), false);
+        }
+
+        public KVMap(Map<byte[], byte[]> map, boolean reverse) {
+            super(reverse ? REVERSE_COMPARATOR : COMPARATOR);
+            putAll(map);
+        }
+    }
+
+    private static class TaggedLock
+    {
+        private final ReadWriteLock rwLock;
+        // ReadWriteLock does not support upgrading read to write.
+        // Tag is checked pre-read.unlock() and must match post-write.lock().
+        private final AtomicLong tag;
+
+        public TaggedLock() {
+            this.rwLock = new ReentrantReadWriteLock(true);
+            this.tag = new AtomicLong(0);
+        }
+
+        public void readUnlock() {
+            rwLock.readLock().unlock();
+        }
+
+        public void writeUnlock() {
+            rwLock.writeLock().unlock();
+        }
+
+        public void readLock(Session session) {
+            tryLock(session, rwLock.readLock(), "shared");
+        }
+
+        public void writeLock(Session session) {
+            tryLock(session, rwLock.writeLock(), "exclusive");
+            tag.incrementAndGet();
+        }
+
+        public void upgradeLock(Session session) {
+            final long saveTag = tag.get();
+            readUnlock();
+            tryLock(session, rwLock.writeLock(), "upgrade");
+            if(saveTag != tag.get()) {
+                writeUnlock();
+                throwTimeout(session, "optimistic upgrade");
+            }
+            tag.incrementAndGet();
+        }
+
+        private static void tryLock(Session session, Lock lock, String lockType) {
+            try {
+                if(!lock.tryLock(LOCK_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)) {
+                    throwTimeout(session, lockType);
+                }
+            } catch(InterruptedException e) {
+                throw new QueryCanceledException(session);
+            }
+        }
+
+        private static void throwTimeout(Session session, String lockType) {
+            LOG.trace("lock timeout: {}", lockType);
+            // No telling where this happened, e.g. row could be half written.
+            getTransactionInternal(session).isRollbackPending = true;
+            throw new LockTimeoutException(LOCK_TIMEOUT_MILLIS, lockType, MemoryTransactionService.class.getSimpleName());
+        }
+    }
+
+    private class MemoryTransactionImpl implements MemoryTransaction
+    {
+        final Session session;
+        final List<UndoOp> undoLog;
+        final Set<BytesHolder> readLocked;
+        final Set<BytesHolder> writeLocked;
+
+        long startMillis;
+        long commitMillis;
+        long bytesWritten;
+        boolean isRollbackPending;
+        Map<ForeignKey,Boolean> deferredForeignKeys;
+        MemoryIndexChecks.PendingChecks pendingChecks;
+
+        private MemoryTransactionImpl(Session session) {
+            this.session = session;
+            this.undoLog = new ArrayList<>();
+            this.readLocked = new HashSet<>();
+            this.writeLocked = new HashSet<>();
+            reset();
+        }
+
+        private void readLock(byte[] rawKey) {
+            BytesHolder key = new BytesHolder(rawKey);
+            if(readLocked.contains(key) || writeLocked.contains(key)) {
+                // Already locked
+                return;
+            }
+            TaggedLock lock = locks.get(key);
+            if(lock == null) {
+                lock = new TaggedLock();
+                TaggedLock prevLock = locks.putIfAbsent(key, lock);
+                if(prevLock != null) {
+                    lock = prevLock;
+                }
+            }
+            lock.readLock(session);
+            readLocked.add(key);
+        }
+
+        private void writeLock(byte[] rawKey) {
+            BytesHolder key = new BytesHolder(rawKey);
+            if(writeLocked.contains(key)) {
+                // Already locked
+                return;
+            }
+            TaggedLock lock = locks.get(key);
+            if(lock == null) {
+                lock = new TaggedLock();
+                TaggedLock prevLock = locks.putIfAbsent(key, lock);
+                if(prevLock != null) {
+                    lock = prevLock;
+                }
+            }
+            if(readLocked.contains(key)) {
+                readLocked.remove(key);
+                lock.upgradeLock(session);
+            } else {
+                lock.writeLock(session);
+            }
+            writeLocked.add(key);
+        }
+
+        public boolean isTimeToCommit() {
+            if(bytesWritten > PERIODIC_COMMIT_BYTES) {
+                return true;
+            }
+            if((System.currentTimeMillis() - startMillis) > PERIODIC_COMMIT_MILLS) {
+                return true;
+            }
+            return false;
+        }
+
+        public void reset() {
+            assert undoLog.isEmpty();
+            assert readLocked.isEmpty();
+            assert writeLocked.isEmpty();
+            startMillis = System.currentTimeMillis();
+            commitMillis = -1;
+            bytesWritten = 0;
+            isRollbackPending = false;
+            if(deferredForeignKeys != null) {
+                deferredForeignKeys.clear();
+            }
+            if(pendingChecks != null) {
+                pendingChecks.clear();
+            }
+        }
+
+        public void runUndo() {
+            if(undoLog.isEmpty()) {
+                return;
+            }
+            // Undo in reverse order than applied
+            ListIterator<UndoOp> it = undoLog.listIterator(undoLog.size());
+            synchronized(db) {
+                while(it.hasPrevious()) {
+                    UndoOp op = it.previous();
+                    op.apply(db);
+                }
+            }
+            undoLog.clear();
+        }
+
+        public void runUnlock() {
+            // Release all locks
+            for(BytesHolder key : readLocked) {
+                TaggedLock lock = locks.get(key);
+                lock.readUnlock();
+            }
+            readLocked.clear();
+            for(BytesHolder key : writeLocked) {
+                TaggedLock lock = locks.get(key);
+                lock.writeUnlock();
+            }
+            writeLocked.clear();
+        }
+
+        //
+        // TreeMapTransaction
+        //
+
+        @Override
+        public byte[] get(byte[] key) {
+            readLock(key);
+            byte[] value;
+            synchronized(db) {
+                value = db.get(key);
+            }
+            return copy(value);
+        }
+
+        @Override
+        public byte[] getUncommitted(byte[] key) {
+            // No lock
+            byte[] value;
+            synchronized(db) {
+                value = db.get(key);
+            }
+            return copy(value);
+        }
+
+        @Override
+        public Iterator<Entry<byte[], byte[]>> getRange(byte[] beginKey, final byte[] endKey) {
+            return getRange(beginKey, endKey, false);
+        }
+
+        @Override
+        public Iterator<Entry<byte[], byte[]>> getRange(byte[] beginKey, byte[] endKey, boolean reverse) {
+            // Duplicate as some consumers want to iterate while calling set/clear
+            final KVMap subMap;
+            synchronized(db) {
+                subMap = new KVMap(db.subMap(beginKey, endKey), reverse);
+            }
+            for(byte[] key : subMap.keySet()) {
+                readLock(key);
+            }
+            final Iterator<Entry<byte[], byte[]>> it = subMap.entrySet().iterator();
+            return new Iterator<Entry<byte[], byte[]>>()  {
+                @Override
+                public boolean hasNext() {
+                    return it.hasNext();
+                }
+
+                @Override
+                public Entry<byte[], byte[]> next() {
+                    Entry<byte[], byte[]> entry = it.next();
+                    return new CopiedEntry(entry);
+                }
+
+                @Override
+                public void remove() {
+                    throw new UnsupportedOperationException();
+                }
+            };
+        }
+
+        @Override
+        public void set(byte[] key, byte[] value) {
+            writeLock(key);
+            byte[] k = copy(key);
+            byte[] v = copy(value);
+            byte[] prev;
+            synchronized(db) {
+                prev = db.put(k, v);
+            }
+            bytesWritten += key.length;
+            bytesWritten += value.length;
+            undoLog.add(new UndoOp(k, prev));
+        }
+
+        @Override
+        public void clear(byte[] key) {
+            writeLock(key);
+            byte[] prev;
+            synchronized(db) {
+                prev = db.remove(key);
+            }
+            bytesWritten += key.length;
+            undoLog.add(new UndoOp(copy(key), prev));
+        }
+
+        @Override
+        public void clearRange(byte[] beginKey, byte[] endKey) {
+            KVMap subMap;
+            synchronized(db) {
+                subMap = new KVMap(db.subMap(beginKey, endKey), false);
+            }
+            for(Entry<byte[], byte[]> entry : subMap.entrySet()) {
+                writeLock(entry.getKey());
+                undoLog.add(new UndoOp(entry.getKey(), entry.getValue()));
+                bytesWritten += entry.getKey().length;
+            }
+            synchronized(db) {
+                for(byte[] key : subMap.keySet()) {
+                    db.remove(key);
+                }
+            }
+        }
+    }
+
+    private static class UndoOp
+    {
+        private final byte[] key;
+        private final byte[] value;
+
+        private UndoOp(byte[] key, byte[] value) {
+            this.key = key;
+            this.value = value;
+        }
+
+        public void apply(KVMap map) {
+            if(value == null) {
+                map.remove(key);
+            } else {
+                map.put(key, value);
+            }
+        }
+
+        @Override
+        public String toString() {
+            return "UndoOp(" + Strings.hex(key) + "=" + (value == null ? null : Strings.hex(value)) + ")";
+        }
+    }
+
+
+    private static void clearStack(Session session, Session.StackKey<Callback> key) {
+        Deque<Callback> stack = session.get(key);
+        if(stack != null) {
+            stack.clear();
+        }
+    }
+
+    private static boolean commitInternal(Session session, boolean allowRetry, boolean clearState) {
+        MemoryTransactionImpl txn = getTransactionInternal(session);
+        boolean shouldRetry = false;
+        RuntimeException re = null;
+        try {
+            if(txn.pendingChecks != null) {
+                txn.pendingChecks.performChecks(session, txn, MemoryIndexChecks.CheckPass.TRANSACTION);
+            }
+            runCallbacks(session, PRE_COMMIT_KEY, txn.startMillis, null);
+            // Not much to do, locks are cleared in end().
+            txn.undoLog.clear();
+            txn.commitMillis = System.currentTimeMillis();
+            runCallbacks(session, AFTER_COMMIT_KEY, txn.commitMillis, null);
+        } catch(RuntimeException e1) {
+            try {
+                rollbackInternal(session, txn);
+                // Only retryable exception from this store
+                if(allowRetry && (e1 instanceof LockTimeoutException)) {
+                    clearState = false;
+                    shouldRetry = true;
+                } else {
+                    re = e1;
+                }
+            } catch(RuntimeException e2) {
+                re = e2;
+            }
+        } finally {
+            end(session, txn, clearState, re);
+        }
+        return shouldRetry;
+    }
+
+    private static byte[] copy(byte[] bytes) {
+        return (bytes == null) ? null : Arrays.copyOf(bytes, bytes.length);
+    }
+
+    private static void end(Session session, MemoryTransactionImpl txn, boolean clearState, RuntimeException cause) {
+        RuntimeException re = cause;
+        try {
+            assert session.get(TXN_KEY) == txn;
+            if(clearState) {
+                session.remove(TXN_KEY);
+            }
+            txn.runUnlock();
+        } catch(RuntimeException e) {
+            re = MultipleCauseException.combine(re, e);
+        } finally {
+            clearStack(session, PRE_COMMIT_KEY);
+            clearStack(session, AFTER_COMMIT_KEY);
+            clearStack(session, AFTER_ROLLBACK_KEY);
+            runCallbacks(session, AFTER_END_KEY, -1, re);
+        }
+    }
+
+    private static Session.StackKey<Callback> getCallbackKey(CallbackType type) {
+        switch(type) {
+            case PRE_COMMIT:    return PRE_COMMIT_KEY;
+            case COMMIT:        return AFTER_COMMIT_KEY;
+            case ROLLBACK:      return AFTER_ROLLBACK_KEY;
+            case END:           return AFTER_END_KEY;
+        }
+        throw new IllegalArgumentException(String.valueOf(type));
+    }
+
+    private static MemoryTransactionImpl getTransactionInternal(Session session) {
+        MemoryTransactionImpl txn = session.get(TXN_KEY);
+        if(txn == null) {
+            throw new NoTransactionInProgressException();
+        }
+        return txn;
+    }
+
+    private static void rollbackInternal(Session session, MemoryTransactionImpl txn) {
+        txn.runUndo();
+        runCallbacks(session, AFTER_ROLLBACK_KEY, -1, null);
+    }
+
+    private static void runCallbacks(Session session, Session.StackKey<Callback> key, long timestamp, RuntimeException cause) {
+        RuntimeException exceptions = cause;
+        Callback cb;
+        while((cb = session.pop(key)) != null) {
+            try {
+                cb.run(session, timestamp);
+            } catch(RuntimeException e) {
+                exceptions = MultipleCauseException.combine(exceptions, e);
+            }
+        }
+        if(exceptions != null) {
+            throw exceptions;
+        }
+    }
+}

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/PersistitStore.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/PersistitStore.java
@@ -572,6 +572,11 @@ public class PersistitStore extends AbstractStore<PersistitStore,Exchange,Persis
         return TableVersionChangedException.class;
     }
 
+    @Override
+    public boolean isRestartable() {
+        return true;
+    }
+
     private static final Callback CLEAR_SESSION_TABLES_CALLBACK = new Callback() {
         @Override
         public void run(Session session, long timestamp) {

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/PersistitStore.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/PersistitStore.java
@@ -563,7 +563,7 @@ public class PersistitStore extends AbstractStore<PersistitStore,Exchange,Persis
     }
 
     @Override
-    public Collection<String> getStorageDescriptionNames() {
+    public Collection<String> getStorageDescriptionNames(Session session) {
         return treeService.getAllTreeNames();
     }
 

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/Store.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/Store.java
@@ -146,7 +146,7 @@ public interface Store extends KeyCreator {
     String getName();
 
     /** (Test helper) Get names of all StorageDescriptions in use. */
-    Collection<String> getStorageDescriptionNames();
+    Collection<String> getStorageDescriptionNames(Session session);
 
     OnlineHelper getOnlineHelper();
 

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/Store.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/Store.java
@@ -153,4 +153,6 @@ public interface Store extends KeyCreator {
     /** (Test helper) Get exception thrown for online DML vs DDL violation */
     Class<? extends Exception> getOnlineDMLFailureException();
 
+    /** (Test helper) Can be restarted and keep data. */
+    boolean isRestartable();
 }

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/format/MemoryStorageDescription.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/format/MemoryStorageDescription.java
@@ -1,0 +1,168 @@
+/**
+ * Copyright (C) 2009-2015 FoundationDB, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.foundationdb.server.store.format;
+
+import com.foundationdb.ais.model.HasStorage;
+import com.foundationdb.ais.model.StorageDescription;
+import com.foundationdb.ais.model.validation.AISValidationFailure;
+import com.foundationdb.ais.model.validation.AISValidationOutput;
+import com.foundationdb.ais.protobuf.AISProtobuf.Storage;
+import com.foundationdb.ais.protobuf.MemoryProtobuf;
+import com.foundationdb.qp.row.Row;
+import com.foundationdb.qp.row.ValuesHolderRow;
+import com.foundationdb.qp.rowtype.RowType;
+import com.foundationdb.qp.rowtype.Schema;
+import com.foundationdb.server.error.AkibanInternalException;
+import com.foundationdb.server.error.StorageDescriptionInvalidException;
+import com.foundationdb.server.service.session.Session;
+import com.foundationdb.server.store.StoreStorageDescription;
+import com.foundationdb.server.store.MemoryStore;
+import com.foundationdb.server.store.MemoryStoreData;
+
+import com.foundationdb.server.types.value.ValueSource;
+import com.foundationdb.server.types.value.ValueSources;
+import com.foundationdb.util.WrappingByteSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Arrays;
+import java.util.UUID;
+
+/** Row<->byte[] via standard Java serialization. */
+public class MemoryStorageDescription extends StoreStorageDescription<MemoryStore,MemoryStoreData>
+{
+    private static final Logger LOG = LoggerFactory.getLogger(MemoryStorageDescription.class);
+
+    private volatile UUID uuid;
+    private volatile byte[] uuidBytes;
+
+    public MemoryStorageDescription(HasStorage forObject, String storageFormat) {
+        super(forObject, storageFormat);
+    }
+
+    public MemoryStorageDescription(HasStorage forObject, MemoryStorageDescription other, String storageFormat) {
+        super(forObject, other, storageFormat);
+        setUUID(other.uuid);
+    }
+
+    public void setUUID(UUID uuid) {
+        assert this.uuid == null;
+        this.uuid = uuid;
+        this.uuidBytes = (uuid == null) ? null : MemoryStore.packUUID(uuid);
+    }
+
+    public UUID getUUID() {
+        return uuid;
+    }
+
+    public byte[] getUUIDBytes() {
+        return uuidBytes;
+    }
+
+    //
+    // StorageDescription
+    //
+
+    @Override
+    public StorageDescription cloneForObject(HasStorage forObject) {
+        return new MemoryStorageDescription(forObject, this, storageFormat);
+    }
+
+    @Override
+    public StorageDescription cloneForObjectWithoutState(HasStorage forObject) {
+        return new MemoryStorageDescription(forObject, storageFormat);
+    }
+
+    @Override
+    public void writeProtobuf(Storage.Builder builder) {
+        builder.setExtension(MemoryProtobuf.uuid, uuid.toString());
+        writeUnknownFields(builder);
+    }
+
+    @Override
+    public Object getUniqueKey() {
+        return uuid;
+    }
+
+    @Override
+    public String getNameString() {
+        return uuid.toString();
+    }
+
+    @Override
+    public void validate(AISValidationOutput output) {
+        if(uuid == null) {
+            output.reportFailure(new AISValidationFailure(new StorageDescriptionInvalidException(object, "is missing UUID")));
+        }
+    }
+
+    //
+    // StoreStorageDescription
+    //
+
+    @Override
+    public Row expandRow(MemoryStore store, Session session, MemoryStoreData storeData, Schema schema) {
+        try {
+            ByteArrayInputStream bais = new ByteArrayInputStream(storeData.rawValue);
+            ObjectInputStream ois = new ObjectInputStream(bais);
+            int tableID = ois.readInt();
+            RowType rowType = schema.tableRowType(tableID);
+            Object[] fields = new Object[rowType.nFields()];
+            for(int i = 0; i < rowType.nFields(); ++i) {
+                fields[i] = ois.readObject();
+            }
+            return new ValuesHolderRow(rowType, fields);
+        } catch(ClassNotFoundException | IOException e) {
+            LOG.error("Expand failure", e);
+            throw new AkibanInternalException("Expand failure", e);
+        }
+    }
+
+    @Override
+    public void packRow(MemoryStore store, Session session, MemoryStoreData storeData, Row row) {
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            ObjectOutputStream oos = new ObjectOutputStream(baos);
+            // Table ID
+            oos.writeInt(row.rowType().table().getTableId());
+            // Values
+            for(int i = 0; i < row.rowType().nFields(); ++i) {
+                ValueSource value = row.value(i);
+                Object o = ValueSources.toObject(value);
+                if(o instanceof WrappingByteSource) {
+                    WrappingByteSource wbs = (WrappingByteSource)o;
+                    byte[] bytes = wbs.byteArray();
+                    if((wbs.byteArrayOffset() != 0) || (wbs.byteArrayLength() != bytes.length)) {
+                        bytes = Arrays.copyOfRange(bytes, wbs.byteArrayOffset(), wbs.byteArrayLength());
+                    }
+                    o = bytes;
+                }
+                oos.writeObject(o);
+            }
+            storeData.rawValue = baos.toByteArray();
+        } catch(IOException e) {
+            LOG.error("Packing failure", e);
+            throw new AkibanInternalException("Pack failure", e);
+        }
+    }
+}

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/format/MemoryStorageFormat.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/format/MemoryStorageFormat.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (C) 2009-2015 FoundationDB, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.foundationdb.server.store.format;
+
+import com.foundationdb.ais.model.HasStorage;
+import com.foundationdb.ais.protobuf.AISProtobuf.Storage;
+import com.foundationdb.ais.protobuf.MemoryProtobuf;
+
+import java.util.UUID;
+
+public class MemoryStorageFormat extends StorageFormat<MemoryStorageDescription>
+{
+    public final static String FORMAT_NAME = "memory";
+
+    private MemoryStorageFormat() {
+    }
+
+    public static void register(StorageFormatRegistry registry) {
+        registry.registerStorageFormat(MemoryProtobuf.uuid,
+                                       FORMAT_NAME,
+                                       MemoryStorageDescription.class,
+                                       new MemoryStorageFormat());
+    }
+
+    public MemoryStorageDescription readProtobuf(Storage pbStorage,
+                                                 HasStorage forObject,
+                                                 MemoryStorageDescription storageDescription) {
+        if(storageDescription == null) {
+            storageDescription = new MemoryStorageDescription(forObject, FORMAT_NAME);
+        }
+        String uuidStr = pbStorage.getExtension(MemoryProtobuf.uuid);
+        if(uuidStr != null) {
+            storageDescription.setUUID(UUID.fromString(uuidStr));
+        }
+        return storageDescription;
+    }
+}

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/format/MemoryStorageFormatRegistry.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/format/MemoryStorageFormatRegistry.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (C) 2009-2015 FoundationDB, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.foundationdb.server.store.format;
+
+import com.foundationdb.ais.model.HasStorage;
+import com.foundationdb.ais.model.NameGenerator;
+import com.foundationdb.ais.model.StorageDescription;
+import com.foundationdb.server.service.config.ConfigurationService;
+import com.foundationdb.server.store.format.protobuf.MemoryProtobufStorageFormat;
+
+import java.util.UUID;
+
+public class MemoryStorageFormatRegistry extends StorageFormatRegistry
+{
+    public MemoryStorageFormatRegistry(ConfigurationService configService) {
+        super(configService);
+    }
+
+    @Override
+    public void registerStandardFormats() {
+        MemoryStorageFormat.register(this);
+        MemoryProtobufStorageFormat.register(this);
+        super.registerStandardFormats();
+    }
+
+    @Override
+    void getDefaultDescriptionConstructor()
+    {}
+
+    // Note: Overrides any configured
+    @Override
+    public StorageDescription getDefaultStorageDescription(HasStorage object) {
+        return new MemoryStorageDescription(object, MemoryStorageFormat.FORMAT_NAME);
+    }
+
+    public boolean isDescriptionClassAllowed(Class<? extends StorageDescription> descriptionClass) {
+        return (super.isDescriptionClassAllowed(descriptionClass) ||
+               MemoryStorageDescription.class.isAssignableFrom(descriptionClass));
+    }
+
+    public void finishStorageDescription(HasStorage object, NameGenerator nameGenerator) {
+        super.finishStorageDescription(object, nameGenerator);
+        assert object.getStorageDescription() != null;
+        if(object.getStorageDescription() instanceof MemoryStorageDescription) {
+            MemoryStorageDescription storageDescription = (MemoryStorageDescription)object.getStorageDescription();
+            if(storageDescription.getUUID() == null) {
+                storageDescription.setUUID(UUID.randomUUID());
+            }
+        }
+    }
+}

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/format/protobuf/MemoryProtobufStorageDescription.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/format/protobuf/MemoryProtobufStorageDescription.java
@@ -1,0 +1,140 @@
+/**
+ * Copyright (C) 2009-2015 FoundationDB, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.foundationdb.server.store.format.protobuf;
+
+import com.foundationdb.ais.model.HasStorage;
+import com.foundationdb.ais.model.StorageDescription;
+import com.foundationdb.ais.model.validation.AISValidationOutput;
+import com.foundationdb.ais.protobuf.AISProtobuf.Storage;
+import com.foundationdb.ais.protobuf.CommonProtobuf.ProtobufRowFormat;
+import com.foundationdb.qp.row.Row;
+import com.foundationdb.qp.rowtype.Schema;
+import com.foundationdb.server.error.ProtobufReadException;
+import com.foundationdb.server.service.session.Session;
+import com.foundationdb.server.store.MemoryStore;
+import com.foundationdb.server.store.MemoryStoreData;
+import com.foundationdb.server.store.format.MemoryStorageDescription;
+import com.google.protobuf.DescriptorProtos.FileDescriptorProto;
+import com.google.protobuf.DynamicMessage;
+import com.google.protobuf.InvalidProtocolBufferException;
+
+import static com.foundationdb.server.store.format.protobuf.ProtobufStorageDescriptionHelper.*;
+
+public class MemoryProtobufStorageDescription extends MemoryStorageDescription implements ProtobufStorageDescription
+{
+    private ProtobufRowFormat.Type formatType;
+    private FileDescriptorProto fileProto;
+    private transient ProtobufRowConverter rowConverter;
+
+    public MemoryProtobufStorageDescription(HasStorage forObject, String storageFormat) {
+        super(forObject, storageFormat);
+    }
+
+    public MemoryProtobufStorageDescription(HasStorage forObject,
+                                            MemoryProtobufStorageDescription other,
+                                            String storageFormat) {
+        super(forObject, other, storageFormat);
+        this.formatType = other.formatType;
+        this.fileProto = other.fileProto;
+    }
+
+    public synchronized ProtobufRowConverter ensureRowConverter() {
+        if(rowConverter == null) {
+            rowConverter = buildRowConverter(object, fileProto);
+        }
+        return rowConverter;
+    }
+
+    public void setFormatType(ProtobufRowFormat.Type formatType) {
+        this.formatType = formatType;
+    }
+
+    public void readProtobuf(ProtobufRowFormat pbFormat) {
+        formatType = pbFormat.getType();
+        fileProto = pbFormat.getFileDescriptor();
+    }
+
+    //
+    // StorageDescription
+    //
+
+    @Override
+    public StorageDescription cloneForObject(HasStorage forObject) {
+        return new MemoryProtobufStorageDescription(forObject, this, storageFormat);
+    }
+
+    @Override
+    public StorageDescription cloneForObjectWithoutState(HasStorage forObject) {
+        MemoryProtobufStorageDescription sd = new MemoryProtobufStorageDescription(forObject, storageFormat);
+        sd.setFormatType(this.formatType);
+        return sd;
+    }
+
+
+    @Override
+    public void writeProtobuf(Storage.Builder builder) {
+        super.writeProtobuf(builder);
+        ProtobufStorageDescriptionHelper.writeProtobuf(builder, formatType, fileProto);
+        writeUnknownFields(builder);
+    }
+
+    @Override
+    public void validate(AISValidationOutput output) {
+        super.validate(output);
+        fileProto = validateAndGenerate(object, formatType, fileProto, output);
+    }
+
+    //
+    // StoreStorageDescription
+    //
+
+    @Override
+    public Row expandRow(MemoryStore store, Session session, MemoryStoreData storeData, Schema schema) {
+        ensureRowConverter();
+        DynamicMessage msg;
+        try {
+            msg = DynamicMessage.parseFrom(rowConverter.getMessageType(), storeData.rawValue);
+        } catch(InvalidProtocolBufferException ex) {
+            ProtobufReadException nex = new ProtobufReadException(rowConverter.getMessageType().getName(), ex.getMessage());
+            nex.initCause(ex);
+            throw nex;
+        }
+        return rowConverter.decode(msg);
+    }
+
+    @Override
+    public void packRow(MemoryStore store, Session session, MemoryStoreData storeData, Row row) {
+        ensureRowConverter();
+        DynamicMessage msg = rowConverter.encode(row);
+        storeData.rawValue = msg.toByteArray();
+    }
+
+    //
+    // ProtobufStorageDescription
+    //
+
+    @Override
+    public FileDescriptorProto getFileProto() {
+        return fileProto;
+    }
+
+    @Override
+    public ProtobufRowFormat.Type getFormatType() {
+        return formatType;
+    }
+}

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/format/protobuf/MemoryProtobufStorageFormat.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/format/protobuf/MemoryProtobufStorageFormat.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (C) 2009-2015 FoundationDB, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.foundationdb.server.store.format.protobuf;
+
+import com.foundationdb.ais.model.HasStorage;
+import com.foundationdb.ais.protobuf.AISProtobuf.Storage;
+import com.foundationdb.ais.protobuf.CommonProtobuf;
+import com.foundationdb.server.store.format.StorageFormat;
+import com.foundationdb.server.store.format.StorageFormatRegistry;
+import com.foundationdb.sql.parser.StorageFormatNode;
+
+public class MemoryProtobufStorageFormat extends StorageFormat<MemoryProtobufStorageDescription>
+{
+    private final static String FORMAT_NAME = "protobuf";
+
+    private MemoryProtobufStorageFormat() {
+    }
+
+    public static void register(StorageFormatRegistry registry) {
+        CustomOptions.registerAllExtensions(registry.getExtensionRegistry());
+        registry.registerStorageFormat(CommonProtobuf.protobufRow,
+                                       FORMAT_NAME,
+                                       MemoryProtobufStorageDescription.class,
+                                       new MemoryProtobufStorageFormat());
+    }
+
+    public MemoryProtobufStorageDescription readProtobuf(Storage pbStorage,
+                                                          HasStorage forObject,
+                                                          MemoryProtobufStorageDescription storageDescription) {
+        if(storageDescription == null) {
+            storageDescription = new MemoryProtobufStorageDescription(forObject, FORMAT_NAME);
+        }
+        storageDescription.readProtobuf(pbStorage.getExtension(CommonProtobuf.protobufRow));
+        return storageDescription;
+    }
+
+
+    public MemoryProtobufStorageDescription parseSQL(StorageFormatNode node, HasStorage forObject) {
+        MemoryProtobufStorageDescription storageDescription = new MemoryProtobufStorageDescription(forObject, FORMAT_NAME);
+        String singleTableOption = node.getOptions().get("no_group");
+        boolean singleTable = (singleTableOption != null) && Boolean.valueOf(singleTableOption);
+        storageDescription.setFormatType(singleTable ?
+                                             CommonProtobuf.ProtobufRowFormat.Type.SINGLE_TABLE :
+                                             CommonProtobuf.ProtobufRowFormat.Type.GROUP_MESSAGE);
+        return storageDescription;
+    }
+}

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/statistics/MemoryIndexStatisticsService.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/statistics/MemoryIndexStatisticsService.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (C) 2009-2015 FoundationDB, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.foundationdb.server.store.statistics;
+
+import com.foundationdb.server.service.config.ConfigurationService;
+import com.foundationdb.server.service.listener.ListenerService;
+import com.foundationdb.server.service.session.SessionService;
+import com.foundationdb.server.service.transaction.TransactionService;
+import com.foundationdb.server.store.SchemaManager;
+import com.foundationdb.server.store.Store;
+import com.foundationdb.server.store.MemoryStore;
+import com.google.inject.Inject;
+
+public class MemoryIndexStatisticsService extends AbstractIndexStatisticsService
+{
+    private final MemoryStore store;
+
+    @Inject
+    public MemoryIndexStatisticsService(Store store,
+                                        TransactionService txnService,
+                                        SchemaManager schemaManager,
+                                        SessionService sessionService,
+                                        ConfigurationService configurationService,
+                                        ListenerService listenerService) {
+        super(store, txnService, schemaManager, sessionService, configurationService, listenerService);
+        this.store = (MemoryStore)store;
+    }
+
+    @Override
+    protected AbstractStoreIndexStatistics createStoreIndexStatistics() {
+        return new MemoryStoreIndexStatistics(store, this);
+    }
+}

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/statistics/MemoryMultiColumnIndexStatisticsVisitor.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/statistics/MemoryMultiColumnIndexStatisticsVisitor.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (C) 2009-2015 FoundationDB, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.foundationdb.server.store.statistics;
+
+import com.foundationdb.ais.model.Index;
+import com.foundationdb.server.service.tree.KeyCreator;
+import com.foundationdb.server.store.statistics.histograms.Sampler;
+import com.persistit.Key;
+
+public class MemoryMultiColumnIndexStatisticsVisitor extends IndexStatisticsGenerator<Key,byte[]>
+{
+    public MemoryMultiColumnIndexStatisticsVisitor(Index index, KeyCreator keyCreator) {
+        super(new PersistitKeyFlywheel(keyCreator), index, index.getKeyColumns().size(), -1);
+    }
+
+    @Override
+    public void visit(Key key, byte[] value) {
+        loadKey(key);
+    }
+
+    @Override
+    public Sampler<Key> createKeySampler(int bucketCount, long distinctCount) {
+        return new Sampler<>(
+            new PersistitKeySplitter(columnCount(), getKeysFlywheel()),
+            bucketCount,
+            distinctCount,
+            getKeysFlywheel()
+        );
+    }
+
+    @Override
+    protected byte[] copyOfKeyBytes(Key key) {
+        byte[] copy = new byte[key.getEncodedSize()];
+        System.arraycopy(key.getEncodedBytes(), 0, copy, 0, copy.length);
+        return copy;
+    }
+}

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/statistics/MemorySingleColumnIndexStatisticsVisitor.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/statistics/MemorySingleColumnIndexStatisticsVisitor.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (C) 2009-2015 FoundationDB, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.foundationdb.server.store.statistics;
+
+import com.foundationdb.ais.model.IndexColumn;
+import com.foundationdb.server.service.tree.KeyCreator;
+import com.foundationdb.server.store.statistics.histograms.Sampler;
+import com.persistit.Key;
+
+import java.util.Map;
+import java.util.TreeMap;
+
+public class MemorySingleColumnIndexStatisticsVisitor extends IndexStatisticsGenerator<Key,byte[]>
+{
+    private final Key extractKey = new Key(null, Key.MAX_KEY_LENGTH);
+    private final Map<Key,int[]> countMap = new TreeMap<>(); // Is ordered required?
+    private final int field;
+
+    public MemorySingleColumnIndexStatisticsVisitor(KeyCreator keyCreator, IndexColumn indexColumn)
+    {
+        super(new PersistitKeyFlywheel(keyCreator), indexColumn.getIndex(), 1, indexColumn.getPosition());
+        this.field = indexColumn.getPosition();
+    }
+
+
+    @Override
+    public void init(int bucketCount, long expectedRowCount) {
+        // Does not do generator init until finish because just
+        // buffering counts in this pass.
+    }
+
+    @Override
+    public void finish(int bucketCount) {
+        // Now init the generator and replay the accumulated counts.
+        super.init(bucketCount, rowCount);
+        try {
+            for(Map.Entry<Key,int[]> entry : countMap.entrySet()) {
+                int keyCount = entry.getValue()[0];
+                for(int i = 0; i < keyCount; ++i) {
+                    loadKey(entry.getKey());
+                }
+            }
+        } finally {
+            super.finish(bucketCount);
+        }
+    }
+
+    @Override
+    public void visit(Key key, byte[] value) {
+        key.indexTo(field);
+        extractKey.clear().appendKeySegment(key);
+        int[] curCount = countMap.get(extractKey);
+        if(curCount == null) {
+            Key storedKey = new Key(extractKey);
+            curCount = new int[1];
+            countMap.put(storedKey, curCount);
+        }
+        curCount[0] += 1;
+        rowCount++;
+    }
+
+    @Override
+    public Sampler<Key> createKeySampler(int bucketCount, long distinctCount) {
+        return new Sampler<>(
+            new PersistitKeySplitter(columnCount(), getKeysFlywheel()),
+            bucketCount,
+            distinctCount,
+            getKeysFlywheel()
+        );
+    }
+
+    @Override
+    protected byte[] copyOfKeyBytes(Key key) {
+        byte[] copy = new byte[key.getEncodedSize()];
+        System.arraycopy(key.getEncodedBytes(), 0, copy, 0, copy.length);
+        return copy;
+    }
+}

--- a/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/statistics/MemoryStoreIndexStatistics.java
+++ b/fdb-sql-layer-core/src/main/java/com/foundationdb/server/store/statistics/MemoryStoreIndexStatistics.java
@@ -1,0 +1,141 @@
+/**
+ * Copyright (C) 2009-2015 FoundationDB, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.foundationdb.server.store.statistics;
+
+import com.foundationdb.ais.model.Index;
+import com.foundationdb.ais.model.IndexColumn;
+import com.foundationdb.ais.model.Table;
+import com.foundationdb.qp.row.Row;
+import com.foundationdb.qp.rowtype.Schema;
+import com.foundationdb.qp.util.SchemaCache;
+import com.foundationdb.server.service.session.Session;
+import com.foundationdb.server.store.MemoryStore;
+import com.foundationdb.server.store.MemoryStoreData;
+import com.persistit.Key;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.foundationdb.server.store.statistics.IndexStatisticsService.INDEX_STATISTICS_TABLE_NAME;
+import static com.foundationdb.server.store.statistics.IndexStatisticsVisitor.VisitorCreator;
+
+public class MemoryStoreIndexStatistics extends AbstractStoreIndexStatistics<MemoryStore> implements VisitorCreator<Key,byte[]> {
+    private static final Logger LOG = LoggerFactory.getLogger(MemoryStoreIndexStatistics.class);
+
+    private final IndexStatisticsService indexStatisticsService;
+
+    public MemoryStoreIndexStatistics(MemoryStore store, IndexStatisticsService indexStatisticsService) {
+        super(store);
+        this.indexStatisticsService = indexStatisticsService;
+    }
+
+    //
+    // AbstractStoreIndexStatistics
+    //
+
+    @Override
+    public IndexStatistics loadIndexStatistics(Session session, Index index) {
+        Table indexStatisticsTable = getStore().getAIS(session).getTable(INDEX_STATISTICS_TABLE_NAME);
+        Table indexTable = index.leafMostTable();
+        Schema schema = SchemaCache.globalSchema(getStore().getAIS(session));
+        MemoryStoreData storeData = getStore().createStoreData(session, indexStatisticsTable.getGroup());
+        storeData.persistitKey.append(indexStatisticsTable.getOrdinal())
+                              .append((long)indexTable.getTableId())
+                              .append((long)index.getIndexId());
+        IndexStatistics result = null;
+        getStore().groupKeyAndDescendantsIterator(session, storeData);
+        while(storeData.next()) {
+            if(result == null) {
+                result = decodeHeader(storeData, index, schema);
+            } else {
+                decodeEntry(storeData, result, schema);
+            }
+        }
+        if((result != null) && LOG.isDebugEnabled()) {
+            LOG.debug("Loaded: {}", result.toString(index));
+        }
+        return result;
+    }
+
+    @Override
+    public void removeStatistics(Session session, Index index) {
+        Table table = getStore().getAIS(session).getTable(INDEX_STATISTICS_TABLE_NAME);
+        Table indexTable = index.leafMostTable();
+        MemoryStoreData storeData = getStore().createStoreData(session, table.getGroup());
+        storeData.persistitKey.clear();
+        storeData.persistitKey.append(table.getOrdinal())
+                              .append((long)indexTable.getTableId())
+                              .append((long)index.getIndexId());
+        getStore().groupKeyAndDescendantsIterator(session, storeData);
+        while(storeData.next()) {
+            Row row = getStore().expandRow(session, storeData, SchemaCache.globalSchema(index.getAIS()));
+            getStore().deleteRow(session, row, false);
+        }
+    }
+
+    @Override
+    public IndexStatistics computeIndexStatistics(Session session, Index index, long scanTimeLimit, long sleepTime) {
+        long indexRowCount = estimateIndexRowCount(session, index);
+        IndexStatisticsVisitor<Key,byte[]> visitor = new IndexStatisticsVisitor<>(session,
+                                                                                  index,
+                                                                                  indexRowCount,
+                                                                                  indexRowCount /*expectedCount*/,
+                                                                                  this);
+        int bucketCount = indexStatisticsService.bucketCount();
+        visitor.init(bucketCount);
+        MemoryStoreData storeData = getStore().createStoreData(session, index);
+        // Whole index, forward.
+        getStore().indexIterator(session, storeData, false);
+        while(storeData.next()) {
+            MemoryStore.unpackKey(storeData);
+            visitor.visit(storeData.persistitKey, storeData.rawValue);
+        }
+        visitor.finish(bucketCount);
+        IndexStatistics indexStatistics = visitor.getIndexStatistics();
+        if(LOG.isDebugEnabled()) {
+            LOG.debug("Analyzed: " + indexStatistics.toString(index));
+        }
+        return indexStatistics;
+    }
+
+    //
+    // VisitorCreator
+    //
+
+    @Override
+    public IndexStatisticsGenerator<Key,byte[]> multiColumnVisitor(Index index) {
+        return new MemoryMultiColumnIndexStatisticsVisitor(index, getStore());
+    }
+
+    @Override
+    public IndexStatisticsGenerator<Key,byte[]> singleColumnVisitor(Session session, IndexColumn indexColumn) {
+        return new MemorySingleColumnIndexStatisticsVisitor(getStore(), indexColumn);
+    }
+
+    //
+    // Internal
+    //
+
+    protected IndexStatistics decodeHeader(MemoryStoreData storeData, Index index, Schema schema) {
+        return decodeIndexStatisticsRow(getStore().expandRow(storeData.session, storeData, schema), index);
+    }
+
+    protected void decodeEntry(MemoryStoreData storeData, IndexStatistics indexStatistics, Schema schema) {
+        decodeIndexStatisticsEntryRow(getStore().expandRow(storeData.session, storeData, schema), indexStatistics);
+    }
+}

--- a/fdb-sql-layer-core/src/main/protobuf/memory_storage_formats.proto
+++ b/fdb-sql-layer-core/src/main/protobuf/memory_storage_formats.proto
@@ -1,0 +1,11 @@
+// TreeMap akiban_information_schema protobuf extensions description file
+
+import "akiban_information_schema.proto";
+
+package akiban_schema.protobuf;
+option java_package = "com.foundationdb.ais.protobuf";
+option java_outer_classname = "MemoryProtobuf";
+
+extend Storage {
+    optional string uuid = 4001;
+}

--- a/fdb-sql-layer-core/src/main/resources/com/foundationdb/server/error/error_code.properties
+++ b/fdb-sql-layer-core/src/main/resources/com/foundationdb/server/error/error_code.properties
@@ -119,6 +119,7 @@ FDB_COMMIT_UNKNOWN_RESULT   = FoundationDB commit unknown: {0}
 FDB_PAST_VERSION            = FoundationDB transaction open too long: {0}
 FDB_FUTURE_VERSION          = FoundationDB transaction needed future version: {0}
 TABLE_VERSION_CHANGED       = Table `{0}` has changed since transaction start
+LOCK_TIMEOUT                = Timeout after {0}ms waiting for {1} lock on {2}
 #
 # Class 42 - syntax error or access rule violation
 #

--- a/fdb-sql-layer-core/src/main/resources/com/foundationdb/server/service/servicemanager/default-services.yaml
+++ b/fdb-sql-layer-core/src/main/resources/com/foundationdb/server/service/servicemanager/default-services.yaml
@@ -33,6 +33,18 @@
     #com.foundationdb.server.service.text.FullTextIndexService: com.foundationdb.server.service.text.FullTextIndexServiceImpl
     ##
     ##
+    ## Memory
+    ##
+    #com.foundationdb.server.store.SchemaManager : com.foundationdb.server.store.MemorySchemaManager
+    #com.foundationdb.server.store.Store : com.foundationdb.server.store.MemoryStore
+    #com.foundationdb.server.store.statistics.IndexStatisticsService : com.foundationdb.server.store.statistics.MemoryIndexStatisticsService
+    #com.foundationdb.server.service.transaction.TransactionService : com.foundationdb.server.store.MemoryTransactionService
+    #com.foundationdb.server.service.statusmonitor.StatusMonitorService : com.foundationdb.server.service.statusmonitor.DummyStatusMonitor
+    #com.foundationdb.server.service.metrics.MetricsService : com.foundationdb.server.service.metrics.DummyMetricsService
+    #com.foundationdb.sql.optimizer.rule.cost.CostModelFactory : com.foundationdb.sql.optimizer.rule.cost.PersistitCostModelService
+    #com.foundationdb.server.service.text.FullTextIndexService: com.foundationdb.server.service.text.ThrowingFullTextService
+    ##
+    ##
     ## FoundationDB
     ##
     com.foundationdb.server.store.FDBHolder : com.foundationdb.server.store.FDBHolderImpl

--- a/fdb-sql-layer-core/src/test/java/com/foundationdb/server/SimpleTableStatusCache.java
+++ b/fdb-sql-layer-core/src/test/java/com/foundationdb/server/SimpleTableStatusCache.java
@@ -33,11 +33,6 @@ public class SimpleTableStatusCache implements TableStatusCache {
     }
     
     @Override
-    public synchronized TableStatus createTableStatus(int tableID) {
-        return new SimpleTableStatus(tableID);
-    }
-
-    @Override
     public synchronized TableStatus getOrCreateVirtualTableStatus(int tableID, VirtualScanFactory factory) {
         VirtualTableStatus status = virtualStatusMap.get(tableID);
         if(status == null) {

--- a/fdb-sql-layer-core/src/test/java/com/foundationdb/server/service/statusmonitor/StatusMonitorServiceImplIT.java
+++ b/fdb-sql-layer-core/src/test/java/com/foundationdb/server/service/statusmonitor/StatusMonitorServiceImplIT.java
@@ -37,11 +37,11 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
 import static org.junit.Assert.*;
 
-public class StatusMonitorServiceIT extends FDBITBase {
+public class StatusMonitorServiceImplIT extends FDBITBase {
 
     /** For use by classes that cannot extend this class directly */
     public static BindingsConfigurationProvider doBind(BindingsConfigurationProvider provider) {
-        return provider.require(StatusMonitorService.class)
+        return provider.bindAndRequire(StatusMonitorService.class, StatusMonitorServiceImpl.class)
                 .require(BasicInfoSchemaTablesService.class)
                 .require(ServerSchemaTablesService.class);
     }

--- a/fdb-sql-layer-core/src/test/java/com/foundationdb/server/test/ApiTestBase.java
+++ b/fdb-sql-layer-core/src/test/java/com/foundationdb/server/test/ApiTestBase.java
@@ -98,6 +98,7 @@ import com.foundationdb.util.tap.TapReport;
 import com.geophile.z.Space;
 import org.junit.Assert;
 import org.junit.After;
+import org.junit.Assume;
 import org.junit.Before;
 
 import com.foundationdb.server.store.Store;
@@ -110,6 +111,7 @@ import com.foundationdb.server.error.NoSuchTableException;
 import com.foundationdb.server.service.ServiceManager;
 import com.foundationdb.server.service.session.Session;
 import org.junit.Rule;
+import org.junit.internal.AssumptionViolatedException;
 import org.junit.rules.MethodRule;
 import org.junit.rules.TestName;
 import org.junit.rules.TestRule;
@@ -241,6 +243,11 @@ public class ApiTestBase {
         public void failed(Throwable e, Description description)  {
             needServicesRestart = true;
         }
+
+        @Override
+        public void skipped(AssumptionViolatedException e, Description description) {
+            needServicesRestart = true;
+        }
     };
 
     /**
@@ -346,6 +353,7 @@ public class ApiTestBase {
     }
 
     public void safeRestartTestServices(Map<String, String> propertiesToPreserve) throws Exception {
+        Assume.assumeTrue("Store#isRestartable()", store().isRestartable());
         final boolean original = TestConfigService.getDoCleanOnUnload();
         try {
             TestConfigService.setDoCleanOnUnload(defaultDoCleanOnUnload());

--- a/fdb-sql-layer-core/src/test/java/com/foundationdb/server/test/it/ITBase.java
+++ b/fdb-sql-layer-core/src/test/java/com/foundationdb/server/test/it/ITBase.java
@@ -201,7 +201,7 @@ public abstract class ITBase extends ApiTestBase {
     public void lookForDanglingStorage() throws Exception {
         // Collect all trees storage currently has
         Set<String> storeTrees = new TreeSet<>();
-        storeTrees.addAll(store().getStorageDescriptionNames());
+        storeTrees.addAll(store().getStorageDescriptionNames(session()));
 
         // Collect all trees in AIS
         Set<String> smTrees = serviceManager().getSchemaManager().getTreeNames(session());

--- a/fdb-sql-layer-core/src/test/java/com/foundationdb/server/test/it/MemoryITBase.java
+++ b/fdb-sql-layer-core/src/test/java/com/foundationdb/server/test/it/MemoryITBase.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (C) 2009-2015 FoundationDB, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.foundationdb.server.test.it;
+
+import com.foundationdb.server.service.servicemanager.GuicedServiceManager.BindingsConfigurationProvider;
+import com.foundationdb.server.service.transaction.TransactionService;
+import com.foundationdb.server.store.MemorySchemaManager;
+import com.foundationdb.server.store.MemoryStore;
+import com.foundationdb.server.store.MemoryTransactionService;
+import com.foundationdb.server.store.SchemaManager;
+import com.foundationdb.server.store.Store;
+import com.foundationdb.server.store.statistics.IndexStatisticsService;
+import com.foundationdb.server.store.statistics.MemoryIndexStatisticsService;
+
+import java.util.Map;
+
+public class MemoryITBase extends ITBase
+{
+    /** For use by classes that cannot extend this class directly */
+    public static BindingsConfigurationProvider doBind(BindingsConfigurationProvider provider) {
+        return provider.bind(SchemaManager.class, MemorySchemaManager.class)
+                       .bind(Store.class, MemoryStore.class)
+                       .bind(IndexStatisticsService.class, MemoryIndexStatisticsService.class)
+                       .bind(TransactionService.class, MemoryTransactionService.class);
+    }
+
+    @Override
+    protected BindingsConfigurationProvider serviceBindingsProvider() {
+        return doBind(super.serviceBindingsProvider());
+    }
+
+    @Override
+    protected Map<String, String> startupConfigProperties() {
+        return uniqueStartupConfigProperties(getClass());
+    }
+}

--- a/fdb-sql-layer-core/src/test/java/com/foundationdb/server/test/mt/InsertUpdateDeleteMT.java
+++ b/fdb-sql-layer-core/src/test/java/com/foundationdb/server/test/mt/InsertUpdateDeleteMT.java
@@ -26,11 +26,15 @@ import com.foundationdb.server.test.mt.util.ThreadMonitor.Stage;
 import com.foundationdb.server.test.mt.util.ConcurrentTestBuilderImpl;
 import com.foundationdb.server.test.mt.util.OperatorCreator;
 import com.foundationdb.server.test.mt.util.TimeMarkerComparison;
+import com.foundationdb.sql.parser.IsolationLevel;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.List;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
 
 /** Basic isolation between SELECTs and concurrent DML. */
@@ -49,6 +53,10 @@ public final class InsertUpdateDeleteMT extends MTBase
 
     @Before
     public void createAndLoad() {
+        Assume.assumeThat(
+            txnService().actualIsolationLevel(IsolationLevel.SNAPSHOT_ISOLATION_LEVEL),
+            is(equalTo(IsolationLevel.SNAPSHOT_ISOLATION_LEVEL))
+        );
         tID = createTable(SCHEMA, TABLE, "id INT NOT NULL PRIMARY KEY, x INT, y INT");
         createIndex(SCHEMA, TABLE, "x", "x");
         tableRowType = SchemaCache.globalSchema(ais()).tableRowType(tID);

--- a/fdb-sql-layer-core/src/test/java/com/foundationdb/sql/aisddl/SequenceDDLIT.java
+++ b/fdb-sql-layer-core/src/test/java/com/foundationdb/sql/aisddl/SequenceDDLIT.java
@@ -109,8 +109,11 @@ public class SequenceDDLIT extends AISDDLITBase {
         txnService().rollbackTransactionIfOpen(session());
 
         txnService().beginTransaction(session());
-        // Expected gap, see nextValue() impl
-        assertEquals("next val c", 3, adapter.sequenceNextValue(s1));
+        // Gap allowed, see nextValue() impl
+        long nextVal1 = adapter.sequenceNextValue(s1);
+        if(nextVal1 < 2) {
+            fail("Expected next val >= 2: " + nextVal1);
+        }
         txnService().commitTransaction(session());
 
         safeRestartTestServices();
@@ -118,9 +121,9 @@ public class SequenceDDLIT extends AISDDLITBase {
 
         s1 = ais().getSequence(seqName);
         txnService().beginTransaction(session());
-        long nextVal = adapter.sequenceNextValue(s1);
-        if(nextVal <= 3) {
-            fail("Expected val > 3: " + nextVal);
+        long nextVal2 = adapter.sequenceNextValue(s1);
+        if(nextVal2 <= nextVal1) {
+            fail("Expected next val > previous next val " + nextVal1 + ": " + nextVal2);
         }
         txnService().commitTransaction(session());
         dropSequence(seqName);

--- a/fdb-sql-layer-pg/src/test/java/com/foundationdb/server/test/mt/ConcurrentStatisticsMT.java
+++ b/fdb-sql-layer-pg/src/test/java/com/foundationdb/server/test/mt/ConcurrentStatisticsMT.java
@@ -58,6 +58,9 @@ public class ConcurrentStatisticsMT extends PostgresMTBase
                         } else {
                             throw new RuntimeException(e);
                         }
+                        if(!conn.getAutoCommit()) {
+                            conn.rollback();
+                        }
                     }
                 }
             } catch(Exception e) {

--- a/fdb-sql-layer-pg/src/test/java/com/foundationdb/server/test/mt/IdentityInsertMT.java
+++ b/fdb-sql-layer-pg/src/test/java/com/foundationdb/server/test/mt/IdentityInsertMT.java
@@ -128,6 +128,7 @@ public class IdentityInsertMT extends PostgresMTBase
                     fail(String.format("Non-retryable error on step %d: (%s) %s\n", i, e.getSQLState(), e.getMessage()));
                 } else {
                     LOG.debug("  Retryable error: {}", e.getSQLState());
+                    s.getConnection().rollback();
                 }
             }
         }

--- a/fdb-sql-layer-pg/src/test/java/com/foundationdb/server/test/mt/IdentityRestartWithMT.java
+++ b/fdb-sql-layer-pg/src/test/java/com/foundationdb/server/test/mt/IdentityRestartWithMT.java
@@ -172,10 +172,11 @@ public class IdentityRestartWithMT extends PostgresMTBase
                 try {
                     ch.step(random);
                 } catch(SQLException e) {
-                    if(!ErrorCode.FDB_NOT_COMMITTED.getFormattedValue().equals(e.getSQLState())) {
+                    if(!ErrorCode.valueOfCode(e.getSQLState()).isRollbackClass()) {
                         fail("Unexpected failure during " + Arrays.toString(ch.mode) + "[" + ch.step + "]: " + e.getMessage());
                     } else {
                         LOG.debug(e.getMessage());
+                        ch.s.execute(SQL_ROLLBACK);
                         ch.changeMode(random);
                     }
                 }

--- a/fdb-sql-layer-pg/src/test/java/com/foundationdb/server/test/mt/PostgresMTBase.java
+++ b/fdb-sql-layer-pg/src/test/java/com/foundationdb/server/test/mt/PostgresMTBase.java
@@ -140,6 +140,13 @@ public class PostgresMTBase extends MTBase
                         }
                         s = null;
                     } else if(code.isRollbackClass()) {
+                        try {
+                            if(!conn.getAutoCommit()) {
+                                conn.rollback();
+                            }
+                        } catch(SQLException e1) {
+                            throw new RuntimeException("Error rolling back", e1);
+                        }
                         // retry after slight delay
                         delay();
                     } else {

--- a/fdb-sql-layer-pg/src/test/java/com/foundationdb/sql/pg/PostgresServerMemoryStoreYamlDT.java
+++ b/fdb-sql-layer-pg/src/test/java/com/foundationdb/sql/pg/PostgresServerMemoryStoreYamlDT.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (C) 2009-2015 FoundationDB, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.foundationdb.sql.pg;
+
+import com.foundationdb.server.service.servicemanager.GuicedServiceManager;
+import com.foundationdb.server.test.it.MemoryITBase;
+import org.junit.Assume;
+
+import java.net.URL;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+/** Run yamls with Memory storage. */
+public class PostgresServerMemoryStoreYamlDT extends PostgresServerMiscYamlIT
+{
+    // These require features not present with memory storage
+    // and are not easy to suppress via yaml
+    private static final Set<String> SKIP_NAMES = new HashSet<>(Arrays.asList(
+        "test-alter-column-keys",
+        "test-alter-table-add-index",
+        "test-create-table",
+        "test-fdb-column-keys-format",
+        "test-fdb-delayed-foreign-key",
+        "test-fdb-delayed-uniqueness",
+        "test-fdb-tuple-format",
+        "test-show-param",
+        "test-storage-format",
+        "test-transaction-isolation-level",
+        "test-pg-readonly4"
+    ));
+
+    public PostgresServerMemoryStoreYamlDT(String caseName, URL url) {
+        super(caseName, url);
+    }
+
+    @Override
+    protected GuicedServiceManager.BindingsConfigurationProvider serviceBindingsProvider() {
+        return MemoryITBase.doBind(super.serviceBindingsProvider());
+    }
+
+    @Override
+    protected void testYaml(URL url) throws Exception {
+        for(String skip : SKIP_NAMES) {
+            Assume.assumeFalse("Skipped", url.getPath().contains(skip));
+        }
+        super.testYaml(url);
+    }
+}

--- a/fdb-sql-layer-pg/src/test/java/com/foundationdb/sql/pg/TransactionPeriodicallyCommitIT.java
+++ b/fdb-sql-layer-pg/src/test/java/com/foundationdb/sql/pg/TransactionPeriodicallyCommitIT.java
@@ -17,9 +17,11 @@
 
 package com.foundationdb.sql.pg;
 
+import com.foundationdb.server.store.FDBStore;
 import com.foundationdb.sql.jdbc.core.BaseConnection;
 import com.foundationdb.sql.jdbc.core.ProtocolConnection;
 import org.junit.After;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -47,6 +49,8 @@ public class TransactionPeriodicallyCommitIT extends PostgresServerITBase {
 
     @Before
     public void createSimpleSchema() throws Exception {
+        // SQL based but actually depends on row sizes and config names.
+        Assume.assumeTrue("FDBStore", store() instanceof FDBStore);
         String sqlCreate = "CREATE TABLE fake.T1 (c1 integer not null primary key)";
         getConnection().createStatement().execute(sqlCreate);
     }


### PR DESCRIPTION
A complete set of classes implementing all of the store interfaces. Ultimately backed by a per-key, pessimistically locked TreeMap.

Demonstrates the the storage abstraction is still sound, albeit a little quirky. Should allow for the majority of the Persistit classes to be removed, which would cascade to also being able to remove RowDef/RowData.

Minor tweaks to existing code (pulled out in separate commits) but otherwise fairly isolated.